### PR TITLE
Tweak test report

### DIFF
--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -464,7 +464,6 @@ class TestCliDocumentFormatter(FormatterMixin, TestCliBase):
                 "top context\n"
                 "  *focused example: PASS\n"
                 "\n"
-                "Finished 1 example(s) in "
                 # TODO add remaining bits of the output (using regexes)
             )
         )
@@ -524,7 +523,6 @@ class TestCliDocumentFormatter(FormatterMixin, TestCliBase):
                 "  nested context\n"
                 "    passing nested example: PASS\n"
                 "\n"
-                "Finished 1 example(s) in "
             ),
         )
 
@@ -541,7 +539,6 @@ class TestCliDocumentFormatter(FormatterMixin, TestCliBase):
                 "  nested context\n"
                 "    passing nested example: PASS\n"
                 "\n"
-                "Finished 1 example(s) in "
             ),
         )
 
@@ -565,7 +562,6 @@ class TestCliDocumentFormatter(FormatterMixin, TestCliBase):
                 "  test_passing: PASS\n"
                 "  test_skipped: SKIP\n"
                 "\n"
-                "Finished 7 example(s) in"
             ),
         )
 

--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -463,7 +463,6 @@ class TestCliDocumentFormatter(FormatterMixin, TestCliBase):
             expected_stdout_startswith=(
                 "top context\n"
                 "  *focused example: PASS\n"
-                "\n"
                 # TODO add remaining bits of the output (using regexes)
             )
         )
@@ -522,7 +521,6 @@ class TestCliDocumentFormatter(FormatterMixin, TestCliBase):
                 "top context\n"
                 "  nested context\n"
                 "    passing nested example: PASS\n"
-                "\n"
             ),
         )
 
@@ -538,7 +536,6 @@ class TestCliDocumentFormatter(FormatterMixin, TestCliBase):
                 "top context\n"
                 "  nested context\n"
                 "    passing nested example: PASS\n"
-                "\n"
             ),
         )
 
@@ -561,7 +558,6 @@ class TestCliDocumentFormatter(FormatterMixin, TestCliBase):
                 "tests.sample_tests.SampleTestCase\n"
                 "  test_passing: PASS\n"
                 "  test_skipped: SKIP\n"
-                "\n"
             ),
         )
 

--- a/tests/cli_unittest.py
+++ b/tests/cli_unittest.py
@@ -159,7 +159,7 @@ class TestCliBase(unittest.TestCase):
             )
 
     @staticmethod
-    def white(text):
+    def bright(text):
         return "\x1b[0m\x1b[1m{}\x1b[0m".format(text)
 
     @staticmethod
@@ -351,7 +351,7 @@ class TestCliDocumentFormatter(FormatterMixin, TestCliBase):
             tty_stdout=True,
             expected_return_code=1,
             expected_stdout_startswith=(
-                self.white("top context")
+                self.bright("top context")
                 + "\r\n"
                 + self.green("  passing example")
                 + "\r\n"
@@ -363,7 +363,7 @@ class TestCliDocumentFormatter(FormatterMixin, TestCliBase):
                 + "\r\n"
                 + self.yellow("  unittest SkipTest")
                 + "\r\n"
-                + self.white("  nested context")
+                + self.bright("  nested context")
                 + "\r\n"
                 + self.green("    passing nested example")
                 + "\r\n"
@@ -380,7 +380,7 @@ class TestCliDocumentFormatter(FormatterMixin, TestCliBase):
         self.run_testslide(
             expected_return_code=1,
             expected_stdout_startswith=(
-                self.white("top context")
+                self.bright("top context")
                 + "\n"
                 + self.green("  passing example")
                 + "\n"
@@ -392,7 +392,7 @@ class TestCliDocumentFormatter(FormatterMixin, TestCliBase):
                 + "\n"
                 + self.yellow("  unittest SkipTest")
                 + "\n"
-                + self.white("  nested context")
+                + self.bright("  nested context")
                 + "\n"
                 + self.green("    passing nested example")
                 + "\n"
@@ -664,31 +664,31 @@ class TestCliLongFormatter(FormatterMixin, TestCliBase):
             tty_stdout=True,
             expected_return_code=1,
             expected_stdout_startswith=(
-                self.white("top context: ")
+                self.bright("top context: ")
                 + self.green("passing example")
                 + "\r\n"
-                + self.white("top context: ")
+                + self.bright("top context: ")
                 + self.red("failing example: SimulatedFailure: test failure (extra)")
                 + "\r\n"
-                + self.white("top context: ")
+                + self.bright("top context: ")
                 + self.green("*focused example")
                 + "\r\n"
-                + self.white("top context: ")
+                + self.bright("top context: ")
                 + self.yellow("skipped example")
                 + "\r\n"
-                + self.white("top context: ")
+                + self.bright("top context: ")
                 + self.yellow("unittest SkipTest")
                 + "\r\n"
-                + self.white("top context, nested context: ")
+                + self.bright("top context, nested context: ")
                 + self.green("passing nested example")
                 + "\r\n"
-                + self.white("tests.sample_tests.SampleTestCase: ")
+                + self.bright("tests.sample_tests.SampleTestCase: ")
                 + self.red("test_failing: AssertionError: Third")
                 + "\r\n"
-                + self.white("tests.sample_tests.SampleTestCase: ")
+                + self.bright("tests.sample_tests.SampleTestCase: ")
                 + self.green("test_passing")
                 + "\r\n"
-                + self.white("tests.sample_tests.SampleTestCase: ")
+                + self.bright("tests.sample_tests.SampleTestCase: ")
                 + self.yellow("test_skipped")
                 + "\r\n"
                 # TODO Rest of the output
@@ -704,31 +704,31 @@ class TestCliLongFormatter(FormatterMixin, TestCliBase):
         self.run_testslide(
             expected_return_code=1,
             expected_stdout_startswith=(
-                self.white("top context: ")
+                self.bright("top context: ")
                 + self.green("passing example")
                 + "\n"
-                + self.white("top context: ")
+                + self.bright("top context: ")
                 + self.red("failing example: SimulatedFailure: test failure (extra)")
                 + "\n"
-                + self.white("top context: ")
+                + self.bright("top context: ")
                 + self.green("*focused example")
                 + "\n"
-                + self.white("top context: ")
+                + self.bright("top context: ")
                 + self.yellow("skipped example")
                 + "\n"
-                + self.white("top context: ")
+                + self.bright("top context: ")
                 + self.yellow("unittest SkipTest")
                 + "\n"
-                + self.white("top context, nested context: ")
+                + self.bright("top context, nested context: ")
                 + self.green("passing nested example")
                 + "\n"
-                + self.white("tests.sample_tests.SampleTestCase: ")
+                + self.bright("tests.sample_tests.SampleTestCase: ")
                 + self.red("test_failing: AssertionError: Third")
                 + "\n"
-                + self.white("tests.sample_tests.SampleTestCase: ")
+                + self.bright("tests.sample_tests.SampleTestCase: ")
                 + self.green("test_passing")
                 + "\n"
-                + self.white("tests.sample_tests.SampleTestCase: ")
+                + self.bright("tests.sample_tests.SampleTestCase: ")
                 + self.yellow("test_skipped")
                 + "\n"
                 # TODO Rest of the output

--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -8,6 +8,7 @@ import io
 import os
 import os.path
 import random
+import re
 import sys
 import time
 import traceback
@@ -171,37 +172,69 @@ class ColorFormatterMixin(BaseFormatter):
     def colored(self):
         return sys.stdout.isatty() or self.force_color
 
+    def remove_terminal_escape(self, text: str) -> str:
+        return re.sub("\033\[[0-9;]+m", "", text)
+
+    def _format_attrs(self, attrs: str, *values: Any) -> str:
+        text = "".join([str(value) for value in values])
+        if self.colored:
+            return "\033[0m\033[{attrs}m{text}\033[0m".format(attrs=attrs, text=text)
+        else:
+            return text
+
     def _print_attrs(self, attrs: str, *values: Any, **kwargs: Any) -> None:
         file = kwargs.get("file", None)
         if file is not None:
             raise ValueError()
         if self.colored:
             print(
-                "\033[0m\033[{attrs}m{value}\033[0m".format(
-                    attrs=attrs, value="".join([str(value) for value in values])
-                ),
+                self._format_attrs(attrs, *values),
                 **kwargs,
             )
         else:
             print(*values, **kwargs)
 
+    def format_bright(self, *values: Any) -> str:
+        return self._format_attrs("1", *values)
+
     def print_bright(self, *values: Any, **kwargs: Any) -> None:
         self._print_attrs("1", *values, **kwargs)
+
+    def format_dim(self, *values: Any) -> str:
+        return self._format_attrs("2", *values)
 
     def print_dim(self, *values: Any, **kwargs: Any) -> None:
         self._print_attrs("2", *values, **kwargs)
 
+    def format_green(self, *values: Any) -> str:
+        return self._format_attrs("32", *values)
+
     def print_green(self, *values: Any, **kwargs: Any) -> None:
         self._print_attrs("32", *values, **kwargs)
+
+    def format_red(self, *values: Any) -> str:
+        return self._format_attrs("31", *values)
 
     def print_red(self, *values: Any, **kwargs: Any) -> None:
         self._print_attrs("31", *values, **kwargs)
 
+    def format_yellow(self, *values: Any) -> str:
+        return self._format_attrs("33", *values)
+
+    def format_yellow_bright(self, *values: Any) -> str:
+        return self._format_attrs("1;33", *values)
+
     def print_yellow(self, *values: Any, **kwargs: Any) -> None:
         self._print_attrs("33", *values, **kwargs)
 
+    def format_cyan(self, *values: Any) -> str:
+        return self._format_attrs("36", *values)
+
     def print_cyan(self, *values: Any, **kwargs: Any) -> None:
         self._print_attrs("36", *values, **kwargs)
+
+    def format_cyan_dim_underline(self, *values: Any) -> str:
+        return self._format_attrs("36;2;4", *values)
 
     def print_cyan_dim_underline(self, *values: Any, **kwargs: Any) -> None:
         self._print_attrs("36;2;4", *values, **kwargs)
@@ -390,18 +423,75 @@ class VerboseFinishMixin(ColorFormatterMixin):
     def _yellow_bright_attr(self, text: str) -> str:
         return self._ansi_attrs("33;1", text)
 
-    def get_ascii_logo(self) -> str:
+    def _get_ascii_logo_lines(self) -> List[str]:
         quote = '"'
         backslash = "\\"
         return f"""
-    {self._yellow_bright_attr("--_")} {self._green_bright_attr(f"|{quote}{quote}---__")}
- {self._red_bright_attr("|'.")}{self._yellow_bright_attr("|  |")}{self._green_bright_attr("|")}  {self._bright_attr(".")}    {self._green_bright_attr(f"{quote}{quote}{quote}|")}
- {self._red_bright_attr("| |")}{self._yellow_bright_attr("|  |")}{self._green_bright_attr("|")} {self._bright_attr(f"/|{backslash}{quote}{quote}-.")}  {self._green_bright_attr("|")}
- {self._red_bright_attr("| |")}{self._yellow_bright_attr("|  |")}{self._green_bright_attr("|")}  {self._bright_attr("|    |")}  {self._green_bright_attr("|")}
- {self._red_bright_attr("| |")}{self._yellow_bright_attr("|  |")}{self._green_bright_attr("|")}  {self._bright_attr(f"|   {backslash}|/")} {self._green_bright_attr("|")}
- {self._red_bright_attr(f"|.{quote}")}{self._yellow_bright_attr("|  |")}{self._green_bright_attr("|")}  {self._bright_attr(f"--{quote}{quote}")} {self._bright_attr("'")}{self._green_bright_attr("__|")}
-    {self._yellow_bright_attr(f"--{quote}")} {self._green_bright_attr(f"|__---{quote}{quote}{quote}")}
-"""
+   {self._yellow_bright_attr("--_")} {self._green_bright_attr(f"|{quote}{quote}---__")}
+{self._red_bright_attr("|'.")}{self._yellow_bright_attr("|  |")}{self._green_bright_attr("|")}  {self._bright_attr(".")}    {self._green_bright_attr(f"{quote}{quote}{quote}|")}
+{self._red_bright_attr("| |")}{self._yellow_bright_attr("|  |")}{self._green_bright_attr("|")} {self._bright_attr(f"/|{backslash}{quote}{quote}-.")}  {self._green_bright_attr("|")}
+{self._red_bright_attr("| |")}{self._yellow_bright_attr("|  |")}{self._green_bright_attr("|")}  {self._bright_attr("|    |")}  {self._green_bright_attr("|")}
+{self._red_bright_attr("| |")}{self._yellow_bright_attr("|  |")}{self._green_bright_attr("|")}  {self._bright_attr(f"|   {backslash}|/")} {self._green_bright_attr("|")}
+{self._red_bright_attr(f"|.{quote}")}{self._yellow_bright_attr("|  |")}{self._green_bright_attr("|")}  {self._bright_attr(f"--{quote}{quote}")} {self._bright_attr("'")}{self._green_bright_attr("__|")}
+   {self._yellow_bright_attr(f"--{quote}")} {self._green_bright_attr(f"|__---{quote}{quote}{quote}")}
+""".split(
+            "\n"
+        )[
+            1:8
+        ]
+
+    def _get_summary_lines(
+        self, total: int, success: int, fail: int, skip: int, not_executed_examples: int
+    ) -> List[str]:
+        summary_lines: List[str] = []
+
+        if self.import_secs and self.import_secs > 2:
+            summary_lines.append(
+                self.format_yellow_bright("Imports took: %.1fs!" % (self.import_secs))
+                + " Profile with "
+                + self.format_bright("--import-profiler")
+                + "."
+            )
+        else:
+            summary_lines.append("")
+
+        example = "examples" if total > 1 else "example"
+        summary_lines.append(
+            self.format_bright(
+                "Executed %s %s in %.1fs:"
+                % (total, example, cast(float, self.duration_secs)),
+            )
+        )
+
+        if success:
+            summary_lines.append(self.format_green("  Successful: ", success))
+        else:
+            summary_lines.append(self.format_dim("  Successful: ", success))
+
+        if fail:
+            summary_lines.append(self.format_red("  Failed: ", fail))
+        else:
+            summary_lines.append(self.format_dim("  Failed: ", fail))
+
+        if skip:
+            summary_lines.append(self.format_yellow("  Skipped: ", skip))
+        else:
+            summary_lines.append(self.format_dim("  Skipped: ", skip))
+
+        if not_executed_examples:
+            summary_lines.append(
+                self.format_cyan("  Not executed: ", not_executed_examples)
+            )
+        else:
+            summary_lines.append(
+                self.format_dim("  Not executed: ", not_executed_examples)
+            )
+
+        summary_lines.append(
+            self.format_cyan_dim_underline("https://testslide.readthedocs.io/")
+        )
+
+        return summary_lines
 
     def finish(self, not_executed_examples: List[Example]) -> None:
         super().finish(not_executed_examples)
@@ -418,58 +508,46 @@ class VerboseFinishMixin(ColorFormatterMixin):
                     number + 1, result["example"], result["exception"]  # type: ignore
                 )
 
-        print("")
-
-        logo_lines = self.get_ascii_logo().split("\n")
-
-        print(logo_lines[1], end="")
-        if total != 1:
-            example = "examples"
-        else:
-            example = "example"
-        self.print_bright(
-            "      Executed %s %s in %.1fs:"
-            % (total, example, cast(float, self.duration_secs)),
+        summary_lines = self._get_summary_lines(
+            total, success, fail, skip, len(not_executed_examples)
+        )
+        max_summary_len = max(
+            [len(self.remove_terminal_escape(line)) for line in summary_lines]
         )
 
-        print(logo_lines[2], end="")
-        if success:
-            self.print_green("    Successful: ", success)
+        logo_lines = self._get_ascii_logo_lines()
+        max_logo_len = max(
+            [len(self.remove_terminal_escape(line)) for line in logo_lines]
+        )
+
+        try:
+            columns, _lines = os.get_terminal_size()
+        except OSError:
+            columns = max_summary_len + max_logo_len + 1
+        if columns > 80:
+            columns = 80
+
+        if max_summary_len + max_summary_len + 1 <= columns:
+            logo_start_column = (
+                columns - max_summary_len - max_logo_len - 2 + max_summary_len
+            )
+            for idx in range(len(summary_lines)):
+                print(
+                    summary_lines[idx],
+                    " "
+                    * (
+                        max_summary_len
+                        - len(self.remove_terminal_escape(summary_lines[idx]))
+                        + (logo_start_column - max_summary_len)
+                    ),
+                    end="",
+                )
+                print(logo_lines[idx])
         else:
-            self.print_dim("    Successful: ", success)
-
-        print(logo_lines[3], end="")
-        if fail:
-            self.print_red("    Failed: ", fail)
-        else:
-            self.print_dim("    Failed: ", fail)
-
-        print(logo_lines[4], end="")
-        if skip:
-            self.print_yellow("    Skipped: ", skip)
-        else:
-            self.print_dim("    Skipped: ", skip)
-
-        print(logo_lines[5], end="")
-        if not_executed_examples:
-            self.print_cyan("    Not executed: ", len(not_executed_examples))
-        else:
-            self.print_dim("    Not executed: ", len(not_executed_examples))
-
-        print(logo_lines[6], end="")
-        if self.import_secs and self.import_secs > 2:
-            self.print_yellow("  Imports took: %.1fs!" % (self.import_secs), end="")
-            print(" Try ", end="")
-            self.print_bright("--import-profiler", end="")
-            print(" to debug it!")
-        else:
-            print()
-
-        print(logo_lines[7], "    ", end="")
-        self.print_cyan_dim_underline("https://testslide.readthedocs.io/")
-
-        # if not_executed_examples:
-        #     self.print_cyan("  Not executed: ", len(not_executed_examples))
+            for idx in range(len(summary_lines)):
+                print(
+                    summary_lines[idx],
+                )
 
 
 ##

--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -527,7 +527,7 @@ class VerboseFinishMixin(ColorFormatterMixin):
         if columns > 80:
             columns = 80
 
-        if max_summary_len + max_summary_len + 1 <= columns:
+        if max_summary_len + max_logo_len + 1 <= columns:
             logo_start_column = (
                 columns - max_summary_len - max_logo_len - 2 + max_summary_len
             )

--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -523,7 +523,8 @@ class VerboseFinishMixin(ColorFormatterMixin):
         try:
             columns, _lines = os.get_terminal_size()
         except OSError:
-            columns = max_summary_len + max_logo_len + 1
+            columns = 80
+
         if columns > 80:
             columns = 80
 


### PR DESCRIPTION
Tweak the test execution report to:

- Show successful, failed, skipped and not executed tests even when it is 0.
  - It is printed in dim white in this case.
  - When there's 1+ examples, it is printed with the same usual color code (green, red, yellow, cyan).
- Improve the message for slow imports, making it more visible and hinting what to do next.
- Add link to documentation: despite being comprehensive, few people refer to it, let's make this better.
- Add nice colored ASCII colored logo, because why not help branding ¯\_(ツ)_/¯

![image](https://user-images.githubusercontent.com/1386232/99729466-e0438a00-2ab2-11eb-828d-4e5cfa2151e4.png)
