### PR TITLE
Improve reset attribute error message & docs

### DIFF
--- a/tests/dsl_unittest.py
+++ b/tests/dsl_unittest.py
@@ -1952,7 +1952,7 @@ class SmokeTestAsync(TestDSLBase):
                     self.assertEqual(self.derived, "derived: new base")
 
         with self.assertRaisesRegex(
-            AttributeError, "^Attribute 'base' is already set.*"
+            AttributeError, "^Attribute 'base' can not be reset.*"
         ):
             self.run_all_examples()
 

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -185,14 +185,14 @@ class _ContextData(object):
     def __setattr__(self, name: str, value: Any) -> None:
         if self.__dict__.get(name) and self.__dict__[name] != value:
             raise AttributeError(
-                f"Attribute {repr(name)} is already set.\n"
-                "Changing the value of attributes after they have been set "
-                "can lead to unexpected test results. Eg: when a sub context "
-                "resets an attribute after a parent context has set and used "
-                "it, they will have different objects for the same attribute.\n"
-                "You can safely override attributes from parent contexts by "
-                "using @context.before, @context.memoize_before or "
-                "@context.function, so the inner-most definition is used."
+                f"Attribute {repr(name)} can not be reset.\n"
+                "Resetting attribute values is not permitted as it can create "
+                "confusion and taint test signal.\n"
+                "You can use memoize/memoize_before instead, as they allow "
+                "attributes from parent contexs to be overridden consistently "
+                "by sub-contexts.\n"
+                "Details and examples at the documentation: "
+                "https://testslide.readthedocs.io/en/master/testslide_dsl/context_attributes_and_functions/index.html"
             )
         else:
             super(_ContextData, self).__setattr__(name, value)


### PR DESCRIPTION
The previous exception message was wrong and confusing. This PR improves this message and the corresponding documentation.