### PR TITLE
Ensure that type validation is executed for StrictMock instances as well

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Generally speaking:
 Here's a quick cookbook on how to have a Python installation working using Docker:
 
 - Install [Docker CE](https://docs.docker.com/install/).
-- Clone the repo: `git clone https://github.com/facebookincubator/TestSlide.git`.
+- Clone the repo: `git clone https://github.com/facebook/TestSlide.git`.
 - Create the Docker image: `docker create --name testslide --interactive --tty --mount type=bind,source="$PWD"/TestSlide,target=/root/src/TestSlide --workdir=/root/src/TestSlide debian /bin/bash`.
 - Start a container with this image: `docker start --interactive testslide`.
 - Install the dependencies: `apt update && apt -y install build-essential curl git libbz2-dev libncurses5-dev libreadline-dev libsqlite3-dev libssl-dev llvm vim wget zlib1g-dev`.

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,6 @@ endif
 .PHONY: all
 all: tests coverage_report docs sdist
 
-# .PHONY does not work for implicit rules, so we FORCE them
-FORCE:
-
 ##
 ## Docs
 ##
@@ -57,7 +54,7 @@ docs_clean:
 ## Tests
 ##
 
-%_unittest.py: FORCE coverage_erase
+%_unittest.py: coverage_erase
 	@printf "${TERM_BRIGHT}UNITTEST $@\n${TERM_NONE}"
 	${Q} coverage run \
 		-m unittest \
@@ -70,15 +67,15 @@ unittest_tests: $(TESTS_SRCS)/*_unittest.py
 
 .PHONY: pytest_tests
 pytest_tests: export PYTHONPATH=${CURDIR}/pytest-testslide:${CURDIR}
-pytest_tests: FORCE coverage_erase
+pytest_tests: coverage_erase
 	@printf "${TERM_BRIGHT}INSTALL pytest_testslide DEPS ${TERM_NONE}\n"
 	${Q} pip install -r pytest-testslide/requirements.txt
 	@printf "${TERM_BRIGHT}PYTEST pytest_testslide${TERM_NONE}\n"
 	${Q} coverage run \
-	-m pytest \
-	pytest-testslide/tests
+		-m pytest \
+		pytest-testslide/tests
 
-%_testslide.py: FORCE coverage_erase
+%_testslide.py: coverage_erase
 	@printf "${TERM_BRIGHT}TESTSLIDE $@\n${TERM_NONE}"
 	${Q} coverage run \
 		-m testslide.cli \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![TestSlide](./docs/testslide_logo.png)
 
-[![Build Status](https://github.com/facebookincubator/TestSlide/workflows/CI/badge.svg)](https://github.com/facebookincubator/TestSlide/actions?query=workflow%3ACI)
-[![Coverage Status](https://coveralls.io/repos/github/facebookincubator/TestSlide/badge.svg?branch=master)](https://coveralls.io/github/facebookincubator/TestSlide?branch=master)
+[![Build Status](https://github.com/facebook/TestSlide/workflows/CI/badge.svg)](https://github.com/facebookincubator/TestSlide/actions?query=workflow%3ACI)
+[![Coverage Status](https://coveralls.io/repos/github/facebook/TestSlide/badge.svg?branch=master)](https://coveralls.io/github/facebookincubator/TestSlide?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/testslide/badge/?version=master)](https://testslide.readthedocs.io/en/master/?badge=master)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![PyPI version](https://badge.fury.io/py/TestSlide.svg)](https://badge.fury.io/py/TestSlide)
@@ -56,7 +56,7 @@ TestSlide's `StrictMock`, `mock_constructor()` and `mock_callable()` are seamles
 
 Run the test and see the failure:
 
-![Failing test](https://raw.githubusercontent.com/facebookincubator/TestSlide/master/docs/test_fail.png)
+![Failing test](https://raw.githubusercontent.com/facebook/TestSlide/master/docs/test_fail.png)
 
 TestSlide's mocks failure messages guide you towards the solution, that you can now implement:
 
@@ -73,7 +73,7 @@ class Backup(object):
 
 And watch the test go green:
 
-![Passing test](https://raw.githubusercontent.com/facebookincubator/TestSlide/master/docs/test_pass.png)
+![Passing test](https://raw.githubusercontent.com/facebook/TestSlide/master/docs/test_pass.png)
 
 It is all about letting the failure messages guide you towards the solution. There's a plethora of validation inside TestSlide's mocks, so you can trust they will help you iterate quickly when writing code and also cover you when breaking changes are introduced.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 - Create a new release tag by running:
     - `./release.sh $new_version`
-- https://github.com/facebookincubator/TestSlide/actions
+- https://github.com/facebook/TestSlide/actions
     - Check if master build is OK.
 - https://readthedocs.org/projects/testslide/
     - Trigger bulid for

--- a/pytest-testslide/setup.py
+++ b/pytest-testslide/setup.py
@@ -21,7 +21,7 @@ setup(
     py_modules=["pytest_testslide"],
     maintainer="Balint Csergo",
     maintainer_email="deathowlzz@gmail.com",
-    url="https://github.com/facebookincubator/TestSlide/tree/master/pytest-testslide",
+    url="https://github.com/facebook/TestSlide/tree/master/pytest-testslide",
     license="MIT",
     description="TestSlide fixture for pytest",
     long_description=readme,

--- a/pytest-testslide/tests/test_pytest_testslide.py
+++ b/pytest-testslide/tests/test_pytest_testslide.py
@@ -76,7 +76,7 @@ def test_pass(testdir):
         async def test_mock_async_callable_unpatching_works(testslide):
             # This will fail if unpatching from test_mock_async_callable_patching_works does
             # not happen
-            assert await sample_module.ParentTarget.async_static_method("a", "b") == "async original response"
+            assert await sample_module.ParentTarget.async_static_method("a", "b") == ["async original response"]
 
         @pytest.mark.asyncio
         async def test_mock_async_callable_assertion_works(testslide):

--- a/pytest-testslide/tests/test_pytest_testslide.py
+++ b/pytest-testslide/tests/test_pytest_testslide.py
@@ -85,8 +85,7 @@ def test_pass(testdir):
 
         def test_mock_async_callable_failing_assertion_works(testslide):
             testslide.mock_async_callable(sample_module.ParentTarget, "async_static_method").for_call("a", "b").to_call_original().and_assert_called_once()
-        
-        
+
         # mock_constructor integration test
         def test_mock_constructor_patching_works(testslide):
             testslide.mock_constructor(sample_module, "ParentTarget").to_raise(RuntimeError("Mocked!"))
@@ -115,7 +114,6 @@ def test_pass(testdir):
             # not happen
             assert sample_module.SomeClass.attribute == "value"
 
-
         def test_aggregated_exceptions(testslide):
             mocked_cls = StrictMock(sample_module.CallOrderTarget)
             testslide.mock_callable(mocked_cls, 'f1')\
@@ -131,7 +129,7 @@ def test_pass(testdir):
     assert "passed, 4 errors" in result.stdout.str()
     assert "failed" not in result.stdout.str()
     expected_failure = re.compile(
-        """.*_______ ERROR at teardown of test_mock_callable_failing_assertion_works ________
+        r""".*_______ ERROR at teardown of test_mock_callable_failing_assertion_works ________
 1 failures.
 <class \'AssertionError\'>: calls did not match assertion.
 \'time\', \'sleep\':

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     packages=["testslide"],
     maintainer="Fabio Pugliese Ornellas",
     maintainer_email="fabio.ornellas@gmail.com",
-    url="https://github.com/facebookincubator/TestSlide",
+    url="https://github.com/facebook/TestSlide",
     license="MIT",
     description="A test framework for Python that makes mocking and iterating over code with tests a breeze",
     long_description=readme,

--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -340,7 +340,7 @@ def _validate_return_type(context):
 
     @context.example
     def passes_for_correct_type(self):
-        self.assert_passes("arg1")
+        self.assert_passes(["arg1"])
 
     @context.example
     def passes_for_mock_without_template(self):
@@ -348,7 +348,7 @@ def _validate_return_type(context):
 
     @context.example
     def passes_for_mock_with_correct_template(self):
-        self.assert_passes(StrictMock(template=str))
+        self.assert_passes([StrictMock(template=str)])
 
     @context.example
     def passes_if_TypeVar_in_signature(self):

--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -175,7 +175,7 @@ def _validate_callable_arg_types(context):
         def ingores_TypeVar(self):
             """
             We currently can't enforce TypeVar:
-            https://github.com/facebookincubator/TestSlide/issues/165
+            https://github.com/facebook/TestSlide/issues/165
             """
 
             def with_typevar(lolo: T) -> None:
@@ -189,7 +189,7 @@ def _validate_callable_arg_types(context):
         def ignores_nested_TypeVar(self):
             """
             We currently can't enforce TypeVar:
-            https://github.com/facebookincubator/TestSlide/issues/165
+            https://github.com/facebook/TestSlide/issues/165
             """
 
             def with_typevar(arg1: Type[T]) -> None:
@@ -354,7 +354,7 @@ def _validate_return_type(context):
     def passes_if_TypeVar_in_signature(self):
         """
         We currently can't enforce TypeVar:
-        https://github.com/facebookincubator/TestSlide/issues/165
+        https://github.com/facebook/TestSlide/issues/165
         """
 
         def with_typevar_return() -> Type[TypeVar("T")]:

--- a/tests/matchers_unittest.py
+++ b/tests/matchers_unittest.py
@@ -285,7 +285,7 @@ class TestUsageWithPatchCallable(testslide.TestCase):
         self.mock_callable(sample_module, "test_function").for_call(
             testslide.matchers.RegexMatches("foo"),
             testslide.matchers.RegexMatches("bar"),
-        ).to_return_value("mocked_response")
+        ).to_return_value(["mocked_response"])
         with self.assertRaises(testslide.mock_callable.UnexpectedCallArguments):
             sample_module.test_function("meh", "moh")
         sample_module.test_function("foo", "bar")

--- a/tests/mock_async_callable_testslide.py
+++ b/tests/mock_async_callable_testslide.py
@@ -39,7 +39,7 @@ def mock_async_callable_tests(context):
 
     @context.memoize_before
     async def value(self):
-        return "mocked value"
+        return ["mocked value"]
 
     ##
     ## Functions
@@ -149,9 +149,9 @@ def mock_async_callable_tests(context):
             mock_kwargs = {k: f"mock {str(v)}" for k, v in self.call_kwargs.items()}
             mock_async_callable(self.target_arg, self.callable_arg).for_call(
                 *mock_args, **mock_kwargs
-            ).to_return_value("mock")
+            ).to_return_value(["mock"])
             self.assertEqual(
-                await self.callable_target(*mock_args, **mock_kwargs), "mock"
+                await self.callable_target(*mock_args, **mock_kwargs), ["mock"]
             )
             if mock_args or mock_kwargs:
                 with self.assertRaises(UnexpectedCallArguments):
@@ -181,7 +181,7 @@ def mock_async_callable_tests(context):
             async def before(self):
                 mock_async_callable(
                     self.target_arg, self.callable_arg
-                ).to_return_values([self.value, "mock2"])
+                ).to_return_values([self.value, ["mock2"]])
                 self.callable_target = getattr(self.real_target, self.callable_arg)
 
             @context.example
@@ -192,7 +192,7 @@ def mock_async_callable_tests(context):
                 )
                 self.assertEqual(
                     await self.callable_target(*self.call_args, **self.call_kwargs),
-                    "mock2",
+                    ["mock2"],
                 )
                 with self.assertRaisesRegex(
                     UndefinedBehaviorForCall, "No more values to return!"
@@ -348,7 +348,7 @@ def mock_async_callable_tests(context):
         async def mock_async_callable_can_not_assert_if_already_received_call(self):
             mock = self.mock_async_callable(
                 self.target_arg, self.callable_arg
-            ).to_return_value("mocked")
+            ).to_return_value(["mocked"])
             await self.callable_target(*self.call_args, **self.call_kwargs)
             with self.assertRaisesRegex(
                 ValueError,

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 attribute = "value"
 typedattr: str = "bruh"
@@ -33,45 +33,47 @@ class SomeClass:
 
 
 class TargetStr(object):
-    def __str__(self):
+    def __str__(self) -> str:
         return "original response"
 
-    def _privatefun(self):
+    def _privatefun(self) -> str:
         return "cannotbemocked"
 
 
 class ParentTarget(TargetStr):
     def instance_method(
         self, arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
-    ) -> str:
-        return "original response"
+    ) -> List[str]:
+        return ["original response"]
 
     async def async_instance_method(
         self, arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
-    ) -> str:
-        return "async original response"
+    ) -> List[str]:
+        return ["async original response"]
 
     @staticmethod
-    def static_method(arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = "") -> str:
-        return "original response"
+    def static_method(
+        arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
+    ) -> List[str]:
+        return ["original response"]
 
     @staticmethod
     async def async_static_method(
         arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
-    ) -> str:
-        return "async original response"
+    ) -> List[str]:
+        return ["async original response"]
 
     @classmethod
     def class_method(
         cls, arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
-    ) -> str:
-        return "original response"
+    ) -> List[str]:
+        return ["original response"]
 
     @classmethod
     async def async_class_method(
         cls, arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
-    ) -> str:
-        return "async original response"
+    ) -> List[str]:
+        return ["async original response"]
 
     async def __aiter__(self):
         return self
@@ -85,7 +87,7 @@ class Target(ParentTarget):
         super(Target, self).__init__()
 
     @property
-    def invalid(self):
+    def invalid(self) -> None:
         """
         Covers a case where create_autospec at an instance would fail.
         """
@@ -93,40 +95,42 @@ class Target(ParentTarget):
 
 
 class CallOrderTarget(object):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.name
 
-    def f1(self, arg):
+    def f1(self, arg: Any) -> str:
         return "f1: {}".format(repr(arg))
 
-    def f2(self, arg):
+    def f2(self, arg: Any) -> str:
         return "f2: {}".format(repr(arg))
 
 
-def test_function(arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = "") -> str:
+def test_function(
+    arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
+) -> List[str]:
     "This function is used by some unit tests only"
-    return "original response"
+    return ["original response"]
 
 
 async def async_test_function(
     arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
-) -> str:
+) -> List[str]:
     "This function is used by some unit tests only"
-    return "original response"
+    return ["original response"]
 
 
 UnionArgType = Dict[str, Union[str, int]]
 
 
-def test_union(arg: UnionArgType):
+def test_union(arg: UnionArgType) -> None:
     pass
 
 
 TupleArgType = Dict[str, Tuple[str, int]]
 
 
-def test_tuple(arg: TupleArgType):
+def test_tuple(arg: TupleArgType) -> None:
     pass

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -292,7 +292,14 @@ def _wrap_signature_and_type_validation(
     with_sig_and_type_validation.__qualname__ = "TestSldeValidation({})".format(
         with_sig_and_type_validation.__qualname__
     )
+    setattr(  # noqa: B010
+        with_sig_and_type_validation, "__is_testslide_type_validation_wrapping", True
+    )
     return with_sig_and_type_validation
+
+
+def _is_wrapped_for_signature_and_type_validation(value: Callable) -> bool:
+    return getattr(value, "__is_testslide_type_validation_wrapping", False)
 
 
 def _validate_return_type(

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -7,6 +7,7 @@ import inspect
 import os
 import sys
 import unittest.mock
+from functools import wraps
 from inspect import Traceback
 from types import FrameType
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Type, Union
@@ -274,6 +275,8 @@ def _wrap_signature_and_type_validation(
 
     skip_first_arg = _skip_first_arg(template, attr_name)
 
+    # Add this so docstrings and method name are not altered by the mock
+    @wraps(callable_template)
     def with_sig_and_type_validation(*args: Any, **kwargs: Any) -> Any:
         if _validate_callable_signature(
             skip_first_arg, callable_template, template, attr_name, args, kwargs
@@ -284,6 +287,11 @@ def _wrap_signature_and_type_validation(
                 )
         return value(*args, **kwargs)
 
+    # Update __qualname__ such that `repr(mocked_function)` would look like
+    # `<function TestSldeValidation(<original_name>) at 0x105c17560>`
+    with_sig_and_type_validation.__qualname__ = "TestSldeValidation({})".format(
+        with_sig_and_type_validation.__qualname__
+    )
     return with_sig_and_type_validation
 
 

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -729,10 +729,9 @@ class _MockCallableDSL(object):
         else:
             original_callable = getattr(self._target, self._method)
 
-        if not isinstance(self._target, StrictMock):
-            new_value = _wrap_signature_and_type_validation(
-                new_value, self._target, self._method, self.type_validation
-            )
+        new_value = _wrap_signature_and_type_validation(
+            new_value, self._target, self._method, self.type_validation
+        )
 
         restore = self._method in self._target.__dict__
         restore_value = self._target.__dict__.get(self._method, None)

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -666,7 +666,14 @@ class StrictMock(object):
                                     raise NonAwaitableReturn(self, name)
 
                                 return_value = await result_awaitable
-                                if not isinstance(
+                                if not testslide.lib._is_wrapped_for_signature_and_type_validation(
+                                    # The original value was already wrapped for type
+                                    # validation. Skipping additional validation to
+                                    # allow, for example, mock_callable to disable
+                                    # validation for a very specific mock call rather
+                                    # for the whole StrictMock instance
+                                    value
+                                ) and not isinstance(
                                     # If the return value is a _BaseRunner then type
                                     # validation, if needed, has already been performed
                                     return_value,
@@ -686,7 +693,14 @@ class StrictMock(object):
                                 return_value = signature_validation_wrapper(
                                     *args, **kwargs
                                 )
-                                if not isinstance(
+                                if not testslide.lib._is_wrapped_for_signature_and_type_validation(
+                                    # The original value was already wrapped for type
+                                    # validation. Skipping additional validation to
+                                    # allow, for example, mock_callable to disable
+                                    # validation for a very specific mock call rather
+                                    # for the whole StrictMock instance
+                                    value
+                                ) and not isinstance(
                                     # If the return value is a _BaseRunner then type
                                     # validation, if needed, has already been performed
                                     return_value,

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -667,7 +667,10 @@ class StrictMock(object):
 
                                 return_value = await result_awaitable
                                 if not isinstance(
-                                    value, testslide.mock_callable._CallableMock
+                                    # If the return value is a _BaseRunner then type
+                                    # validation, if needed, has already been performed
+                                    return_value,
+                                    testslide.mock_callable._BaseRunner,
                                 ):
                                     testslide.lib._validate_return_type(
                                         template_value,
@@ -683,8 +686,11 @@ class StrictMock(object):
                                 return_value = signature_validation_wrapper(
                                     *args, **kwargs
                                 )
-                                if self.__dict__["_type_validation"] and not isinstance(
-                                    value, testslide.mock_callable._CallableMock
+                                if not isinstance(
+                                    # If the return value is a _BaseRunner then type
+                                    # validation, if needed, has already been performed
+                                    return_value,
+                                    testslide.mock_callable._BaseRunner,
                                 ):
                                     testslide.lib._validate_return_type(
                                         template_value,

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -198,6 +198,11 @@ class _MethodProxy(object):
         memo[id(self)] = self_copy
         return self_copy
 
+    def __repr__(self) -> str:
+        # Override repr to have a representation that provides information
+        # about the wrapped method
+        return repr(self.__dict__["_value"])
+
 
 class StrictMock(object):
     """

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -391,7 +391,7 @@ class StrictMock(object):
         Populate all template's magic methods with expected default behavior.
         This is important as things such as bool() depend on they existing
         on the object's class __dict__.
-        https://github.com/facebookincubator/TestSlide/issues/23
+        https://github.com/facebook/TestSlide/issues/23
         """
         if not self._template:
             return

--- a/util/testslide-snippets/package.json
+++ b/util/testslide-snippets/package.json
@@ -6,7 +6,7 @@
     "icon": "icon.png",
     "repository": {
         "type": "github",
-        "url": "https://github.com/facebookincubator/TestSlide"
+        "url": "https://github.com/facebook/TestSlide"
     },
     "version": "2.6.4",
     "engines": {


### PR DESCRIPTION
<!-- 
Thank you for your interest in this project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct of this project which can be found at https://github.com/facebookincubator/TestSlide/blob/master/CODE_OF_CONDUCT.md 

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines which can  be found at https://github.com/facebookincubator/TestSlide/blob/master/CONTRIBUTING.md

-->

While debugging some issue into some FB internal tests (which I was expecting failing) I've noticed that using `mock_callable` / `mock_async_callable` on `StrictMock` does not enable type validation.
This feels like an oversight on the code and has the potential to have users (myself included) writing tests expecting the framework to be validating the types (and as such ensuring that the mocks are consistent with the typing annotations).

A super small representative example is available on https://gist.github.com/macisamuele/b6e85ddfad7f5802ebedd5a2a0810c6c

This PR does also fixes/improves few more details:
* ensure that functions wrapped for type checking are not altering function name and docstring (debuggability)
* removes redundant `FORCE` Makefile target
* updates the repository link in `setup.py`

## What:

<!-- What changes are being made? (Link the feature request/issue that is being fixed here) -->


## Why:

<!-- Why are these changes necessary? -->

These changes are needed to ensure that `mock_callable` and `mock_async_callable` does preserve type validation regardless of the target being a *real* instance or a `StrictMock` instance.

**NOTE**: In order to make the change possible and well defined it does modify the `tests.sample_module` (6be4622482e77b45ce240ffbf8804ac75fbb30ae) in order to have the methods returning `Iterable`s instead of `str`s.
This is needed because current testing (`mock_callable_testslide.py`) does mock `class_method` with `to_yield_values` which is incompatible from a typing prospective. Fixing the tests would have required more work respect fixing the module class and it is safe because the module is used only for testing purposes.

## How:

<!-- How were these changes implemented? -->

The `mock_callable` implementation was intentionally excluding `StrictMock` instances to be wrapped by type validation, this PR *just* removed this exclusion.

## Risks:
<!-- Any possible risks you've likely introduced in this PR?  -->

Users of the library which have been relying on the lack of type validation on mocked functions on `StrictMock`s would see their tests failing.
This is intentional as the lack of the type validation in such cases was a bug and not considered a feature.
For these users, my suggestion would be to fix their tests or to add `type_validation=False` into the `mock_(async_)callable` definition (the later is discouraged as it hides the issue instead of solving it)

## Checklist

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [x] Added tests, if you've added code that should be tested
- [ ] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
