### PR TITLE
Fix master

### DIFF
--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -118,7 +118,6 @@ class Template(TemplateParent):
 class TemplateBaseStrictMock(StrictMock):
     def __init__(self):
         super().__init__(template=Template)
-        self.__instance_method_return = "mock"
 
     @staticmethod
     def static_method(message):
@@ -130,6 +129,7 @@ class TemplateBaseStrictMock(StrictMock):
 
 class TemplateStrictMock(TemplateBaseStrictMock):
     def instance_method(self, message):
+        self.__instance_method_return = "mock"
         return self.__instance_method_return
 
 

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -626,9 +626,10 @@ class StrictMock(object):
     def __validate_and_wrap_mock_value(self, name: str, value: Any) -> Any:
         if self._template:
             if not self.__template_has_attr(name):
-                if not (name.startswith(f"_{type(self).__name__}__") and not name.endswith(
-                    "__"
-                )):
+                if not (
+                    name.startswith(f"_{type(self).__name__}__")
+                    and not name.endswith("__")
+                ):
                     raise NonExistentAttribute(self, name)
 
             self.__validate_attribute_type(name, value)


### PR DESCRIPTION
The tests were correctly breaking after a clowny change in master (guilty!). This PR fixes the object used in the test, so it passes.