### PR TITLE
raising ValueError at the constructor

### DIFF
--- a/testslide/matchers.py
+++ b/testslide/matchers.py
@@ -53,6 +53,8 @@ class _AndMatcher(_AlreadyChainedMatcher):
     """
 
     def __init__(self, a: Matcher, b: Matcher) -> None:
+        if type(a) != type(Matcher()) or type(b) != type(Matcher()):
+            raise ValueError("Not of type Matcher")
         self.a = a
         self.b = b
 
@@ -65,6 +67,8 @@ class _AndMatcher(_AlreadyChainedMatcher):
 
 class _XorMatcher(_AlreadyChainedMatcher):
     def __init__(self, a: Matcher, b: Matcher) -> None:
+        if type(a) != type(Matcher()) or type(b) != type(Matcher()):
+            raise ValueError("Not of type Matcher")
         self.a = a
         self.b = b
 
@@ -90,6 +94,8 @@ class _InvMatcher(_AlreadyChainedMatcher):
 
 class _OrMatcher(_AlreadyChainedMatcher):
     def __init__(self, a: Matcher, b: Matcher) -> None:
+        if type(a) != type(Matcher()) or type(b) != type(Matcher()):
+            raise ValueError("Not of type Matcher")
         self.a = a
         self.b = b
 


### PR DESCRIPTION
<!-- 
Thank you for your interest in this project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct of this project which can be found at https://github.com/facebookincubator/TestSlide/blob/master/CODE_OF_CONDUCT.md 

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines which can  be found at https://github.com/facebookincubator/TestSlide/blob/master/CONTRIBUTING.md

-->

**What:**

https://github.com/facebook/TestSlide/issues/233

**Why:**

An error was raised when the comparison of two non-similar type data were compared. To be more technically correct, the error should be raised at the time of creating an instance. And thereby this solution.

**How:**

Compared the input arguments, passed at the time of constructor call, with the type of class Matcher. If the two type do not match, a Value Error is raised.

**Risks:**

No Such risks are possible as far as I understand the use of the particular constructors.

**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [ ] Added tests, if you've added code that should be tested N/A
- [ ] Updated the documentation, if you've changed APIs N/A
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->

I need some opinion about what exactly to be written for the error message.
