### PR TITLE
raise value error from the constructor level

### DIFF
--- a/tests/matchers_unittest.py
+++ b/tests/matchers_unittest.py
@@ -279,6 +279,34 @@ class TestChaining(testslide.TestCase):
         with self.assertRaises(testslide.matchers.AlreadyChainedException):
             testslide.matchers.Any() ^ testslide.matchers.AnyStr() ^ testslide.matchers.AnyInt()
 
+    def testValueError(self):
+        # tests for _AndMatcher constructor call
+        self.assertRaises(ValueError, testslide.matchers._AndMatcher, 10, 30)
+        self.assertRaises(
+            ValueError, testslide.matchers._AndMatcher, 10, testslide.matchers.Matcher()
+        )
+        self.assertRaises(
+            ValueError, testslide.matchers._AndMatcher, testslide.matchers.Matcher(), 10
+        )
+
+        # tests for _XorMatcher constructor call
+        self.assertRaises(ValueError, testslide.matchers._XorMatcher, 10, 30)
+        self.assertRaises(
+            ValueError, testslide.matchers._XorMatcher, 10, testslide.matchers.Matcher()
+        )
+        self.assertRaises(
+            ValueError, testslide.matchers._XorMatcher, testslide.matchers.Matcher(), 10
+        )
+
+        # tests for _OrMatcher constructor call
+        self.assertRaises(ValueError, testslide.matchers._OrMatcher, 10, 30)
+        self.assertRaises(
+            ValueError, testslide.matchers._OrMatcher, 10, testslide.matchers.Matcher()
+        )
+        self.assertRaises(
+            ValueError, testslide.matchers._OrMatcher, testslide.matchers.Matcher(), 10
+        )
+
 
 class TestUsageWithPatchCallable(testslide.TestCase):
     def test_patch_callable(self):

--- a/testslide/matchers.py
+++ b/testslide/matchers.py
@@ -53,6 +53,10 @@ class _AndMatcher(_AlreadyChainedMatcher):
     """
 
     def __init__(self, a: Matcher, b: Matcher) -> None:
+        if not isinstance(a, Matcher) or not isinstance(b, Matcher):
+            raise ValueError(
+                f"Unexpected argument(s) of type '{type(a).__name__}' and '{type(b).__name__}'. Expected 'Matcher' and 'Matcher'."
+            )
         self.a = a
         self.b = b
 
@@ -65,6 +69,10 @@ class _AndMatcher(_AlreadyChainedMatcher):
 
 class _XorMatcher(_AlreadyChainedMatcher):
     def __init__(self, a: Matcher, b: Matcher) -> None:
+        if not isinstance(a, Matcher) or not isinstance(b, Matcher):
+            raise ValueError(
+                f"Unexpected argument(s) of type '{type(a).__name__}' and '{type(b).__name__}'. Expected 'Matcher' and 'Matcher'."
+            )
         self.a = a
         self.b = b
 
@@ -90,6 +98,10 @@ class _InvMatcher(_AlreadyChainedMatcher):
 
 class _OrMatcher(_AlreadyChainedMatcher):
     def __init__(self, a: Matcher, b: Matcher) -> None:
+        if not isinstance(a, Matcher) or not isinstance(b, Matcher):
+            raise ValueError(
+                f"Unexpected argument(s) of type '{type(a).__name__}' and '{type(b).__name__}'. Expected 'Matcher' and 'Matcher'."
+            )
         self.a = a
         self.b = b
 


### PR DESCRIPTION
<!-- 
Thank you for your interest in this project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct of this project which can be found at https://github.com/facebookincubator/TestSlide/blob/master/CODE_OF_CONDUCT.md 

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines which can  be found at https://github.com/facebookincubator/TestSlide/blob/master/CONTRIBUTING.md

-->

**What:**

<!-- What changes are being made? (Link the feature request/issue that is being fixed here) -->
https://github.com/facebook/TestSlide/issues/233

**Why:**

<!-- Why are these changes necessary? -->
An error was raised when the comparison of two non-similar type data were compared. To be more technically correct, the error should be raised at the time of creating an instance. And thereby this solution.

**How:**

<!-- How were these changes implemented? -->
Compared the input arguments, passed at the time of constructor call, with the type of class Matcher. If the two type do not match, a Value Error is raised.

**Risks:**

<!-- Any possible risks you've likely introduced in this PR?  -->
No Such risks are possible as far as I understand the use of the particular constructors. The only issues am concerned about is that the `make install_build_deps` does not install `typeguard` and `psutil`. That can be a reason for the tests to fail. 

**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")

- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs N/A

<!-- feel free to add additional comments -->

Two points to draw attention.
1. The `make install_build_deps` does not install `typeguard` and `psutil`.
2. If ValueError message "Not of type Matcher" is ok?