### PR TITLE
Raise Exception from AnyInstanceOf Constructor

### DIFF
--- a/tests/matchers_unittest.py
+++ b/tests/matchers_unittest.py
@@ -134,12 +134,8 @@ class GenericTestCase(testslide.TestCase):
         self.assertNotEqual(testslide.matchers.AnyInstanceOf(str), 7)
 
     def testTriggeringAnyInstanceOfException(self):
-        c = sample_module.SomeClass()
         with self.assertRaises(ValueError):
-            self.mock_callable(c, "method").for_call(
-                testslide.matchers.AnyInstanceOf(2)
-            ).to_return_value("mocked_response")
-            c.method()
+            testslide.matchers.AnyInstanceOf(2)
 
     def testAnyWithCall(self):
         self.assertEqual(testslide.matchers.AnyWithCall(lambda x: "b" in x), "abc")

--- a/tests/matchers_unittest.py
+++ b/tests/matchers_unittest.py
@@ -131,8 +131,6 @@ class GenericTestCase(testslide.TestCase):
 
     def testAnyInstanceOf(self):
         self.assertEqual(testslide.matchers.AnyInstanceOf(str), "durrdurr")
-
-    def testTriggeringAnyInstanceOfException(self):
         self.assertNotEqual(testslide.matchers.AnyInstanceOf(str), 7)
         with self.assertRaises(ValueError):
             testslide.matchers.AnyInstanceOf(2)

--- a/tests/matchers_unittest.py
+++ b/tests/matchers_unittest.py
@@ -131,9 +131,9 @@ class GenericTestCase(testslide.TestCase):
 
     def testAnyInstanceOf(self):
         self.assertEqual(testslide.matchers.AnyInstanceOf(str), "durrdurr")
-        self.assertNotEqual(testslide.matchers.AnyInstanceOf(str), 7)
 
     def testTriggeringAnyInstanceOfException(self):
+        self.assertNotEqual(testslide.matchers.AnyInstanceOf(str), 7)
         with self.assertRaises(ValueError):
             testslide.matchers.AnyInstanceOf(2)
 

--- a/tests/matchers_unittest.py
+++ b/tests/matchers_unittest.py
@@ -133,6 +133,14 @@ class GenericTestCase(testslide.TestCase):
         self.assertEqual(testslide.matchers.AnyInstanceOf(str), "durrdurr")
         self.assertNotEqual(testslide.matchers.AnyInstanceOf(str), 7)
 
+    def testTriggeringAnyInstanceOfException(self):
+        c = sample_module.SomeClass()
+        with self.assertRaises(ValueError):
+            self.mock_callable(c, "method").for_call(
+                testslide.matchers.AnyInstanceOf(2)
+            ).to_return_value("mocked_response")
+            c.method()
+
     def testAnyWithCall(self):
         self.assertEqual(testslide.matchers.AnyWithCall(lambda x: "b" in x), "abc")
         self.assertNotEqual(testslide.matchers.AnyWithCall(lambda x: "d" in x), "abc")

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -19,7 +19,7 @@ class SomeClass:
     other_class_attribute = OtherClass
     typedattr: str = "bruh"
 
-    def method(self):
+    def method(self, *args, **kwargs):
         pass
 
     @property

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -19,7 +19,7 @@ class SomeClass:
     other_class_attribute = OtherClass
     typedattr: str = "bruh"
 
-    def method(self, *args, **kwargs):
+    def method(self):
         pass
 
     @property

--- a/testslide/matchers.py
+++ b/testslide/matchers.py
@@ -422,6 +422,12 @@ class AnyFalsey(Matcher):
 
 class AnyInstanceOf(_RichComparison):
     def __init__(self, klass: type) -> None:
+        if not isinstance(klass, type):
+            raise ValueError(
+                "AnyInstanceOf(...) expects a type while a '{}' ('{}') was provided".format(
+                    type(klass).__name__, klass
+                )
+            )
         super().__init__(klass=klass)
 
 


### PR DESCRIPTION
<!-- 
Thank you for your interest in this project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct of this project which can be found at https://github.com/facebookincubator/TestSlide/blob/master/CODE_OF_CONDUCT.md 

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines which can  be found at https://github.com/facebookincubator/TestSlide/blob/master/CONTRIBUTING.md

-->

**What:**

<!-- What changes are being made? (Link the feature request/issue that is being fixed here) -->
#233 

**Why:**

<!-- Why are these changes necessary? -->

**How:**

<!-- How were these changes implemented? -->
Checked for the input arguments of the `AnyInstanceOf` to be of an instance of `type`. If not, raise a `ValueError` exception.

**Risks:**

<!-- Any possible risks you've likely introduced in this PR?  -->

**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
Do I need to add the "correct usage" of the AnyInstanceOf in the tests?