### PR TITLE
Enable running all tests to completion even if one python version failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
+      # Ensure that all flavours are run to completion even if an other flavor failed
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
**What:**
Ensure that we do run all the tests (platforms/python-versions) and that we don't immediately stop if one has failed.
This is a follow-up from #292

**Why:**
In case of test failures is extremely interesting to have information about "is this failure a genuine bug or is an issue with a single python version?".

**How:**
Ensure that github workflow is correctly defined. Doc in [here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)

**Risks:**

n/a

**Checklist**:

- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")
