### PR TITLE
Use get_typing_hints instead of __annotations__ to resolve types in Python 3.10

### DIFF
--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -7,7 +7,17 @@ import dis
 import inspect
 import os.path
 from types import FrameType
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union, get_type_hints
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Type,
+    Union,
+    get_type_hints,
+)
 
 import testslide.lib
 import testslide.mock_callable

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -634,7 +634,11 @@ class StrictMock(object):
             return
 
         if self._template is not None:
-            annotations = get_type_hints(self._template)
+            try:
+                annotations = get_type_hints(self._template)
+            except KeyError:
+                # Some modules can throw KeyError : https://bugs.python.org/issue41515
+                annotations = {}
             if name in annotations:
                 testslide.lib._validate_argument_type(annotations[name], name, value)
 

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -623,9 +623,10 @@ class StrictMock(object):
         ):
             return
 
-        annotations = get_type_hints(self._template)
-        if name in annotations:
-            testslide.lib._validate_argument_type(annotations[name], name, value)
+        if self._template is not None:
+            annotations = get_type_hints(self._template)
+            if name in annotations:
+                testslide.lib._validate_argument_type(annotations[name], name, value)
 
     def __validate_and_wrap_mock_value(self, name: str, value: Any) -> Any:
         if self._template:

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -7,7 +7,7 @@ import dis
 import inspect
 import os.path
 from types import FrameType
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union, get_type_hints
 
 import testslide.lib
 import testslide.mock_callable
@@ -623,10 +623,9 @@ class StrictMock(object):
         ):
             return
 
-        if hasattr(self._template, "__annotations__"):
-            annotations = self._template.__annotations__
-            if name in annotations:
-                testslide.lib._validate_argument_type(annotations[name], name, value)
+        annotations = get_type_hints(self._template)
+        if name in annotations:
+            testslide.lib._validate_argument_type(annotations[name], name, value)
 
     def __validate_and_wrap_mock_value(self, name: str, value: Any) -> Any:
         if self._template:

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -636,7 +636,7 @@ class StrictMock(object):
         if self._template is not None:
             try:
                 annotations = get_type_hints(self._template)
-            except KeyError:
+            except Exception:
                 # Some modules can throw KeyError : https://bugs.python.org/issue41515
                 annotations = {}
             if name in annotations:


### PR DESCRIPTION
**What:**

Fixes #296 

**Why:**

Due to PEP 563 becoming default in Python 3.10 the `__annotations__` value doesn't store types and it stores string values. Using `typing.get_type_hints` ensures the types are evaluated and returned like behavior before Python 3.10 .

**How:**

<!-- How were these changes implemented? -->

**Risks:**

<!-- Any possible risks you've likely introduced in this PR?  -->

**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [ ] Added tests, if you've added code that should be tested
- [ ] Updated the documentation, if you've changed APIs
- [ ] Ensured the test suite passes
- [ ] Made sure your code lints
- [ ] Completed the Contributor License Agreement ("CLA")
