### PR TITLE
Remove antequated "(object)" notation from testslide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install TestSlide
 Scaffold the code you want to test `backup.py`:
 
 ```python
-class Backup(object):
+class Backup:
   def delete(self, path):
     pass
 ```
@@ -63,7 +63,7 @@ TestSlide's mocks failure messages guide you towards the solution, that you can 
 ```python
 import storage
 
-class Backup(object):
+class Backup:
   def __init__(self):
     self.storage = storage.Client(timeout=60)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Scaffold the code you want to test ``backup.py``:
 
 .. code-block:: python
 
-  class Backup(object):
+  class Backup:
     def delete(self, path):
       pass
 
@@ -61,7 +61,7 @@ TestSlide's mocks failure messages guide you towards the solution, that you can 
 
   import storage
 
-  class Backup(object):
+  class Backup:
     def __init__(self):
       self.storage = storage.Client(timeout=60)
 

--- a/docs/patching/mock_constructor/index.rst
+++ b/docs/patching/mock_constructor/index.rst
@@ -6,11 +6,11 @@ Let's say we want to unit test the ``Backup.delete`` method:
 .. code-block:: python
 
   import storage
-  
-  class Backup(object):
+
+  class Backup:
     def __init__(self):
       self.storage = storage.Client(timeout=60)
-  
+
     def delete(self, path):
       self.storage.delete(path)
 
@@ -32,7 +32,7 @@ The question now is: how to put ``self.storage_mock`` inside ``Backup.__init__``
   from testslide import TestCase, StrictMock, mock_callable
   import storage
   from backup import Backup
-  
+
   class TestBackupDelete(TestCase):
     def setUp(self):
       super().setUp()
@@ -40,7 +40,7 @@ The question now is: how to put ``self.storage_mock`` inside ``Backup.__init__``
       self.mock_constructor(storage, 'Client')\
         .for_call(timeout=60)\
         .to_return_value(self.storage_mock)
-  
+
     def test_delete_from_storage(self):
       self.mock_callable(self.storage_mock, 'delete')\
         .for_call('/file/to/delete')\
@@ -65,11 +65,11 @@ Type Validation
 
   import sys
   import testslide, testslide.lib
-  
+
   class Messenger:
       def __init__(self, message: str):
         self.message = message
-  
+
   class TestArgumentTypeValidation(testslide.TestCase):
       def test_argument_type_validation(self):
           messenger_mock = testslide.StrictMock(template=Messenger)

--- a/docs/strict_mock/index.rst
+++ b/docs/strict_mock/index.rst
@@ -142,7 +142,7 @@ This validation works even for attributes set by ``__init__``, as ``StrictMock``
   In [1]: from testslide import StrictMock
      ...:
 
-  In [2]: class DynamicAttr(object):
+  In [2]: class DynamicAttr:
      ...:     def __init__(self):
      ...:          self.dynamic = 'set from __init__'
      ...:
@@ -512,7 +512,7 @@ By default, ``StrictMock`` will validate arguments passed to callable attributes
 
   In [1]: from testslide import StrictMock
 
-  In [2]: class CallableObject(object):
+  In [2]: class CallableObject:
      ...:   def __call__(self):
      ...:     pass
      ...:
@@ -521,7 +521,7 @@ By default, ``StrictMock`` will validate arguments passed to callable attributes
 
   In [4]: s.attr = CallableObject()
 
-  In [5]: type(s.attr)  
+  In [5]: type(s.attr)
   Out[5]: testslide.strict_mock._MethodProxy
 
   In [6]: s = StrictMock(type_validation=False)

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -13,11 +13,11 @@ from testslide.mock_callable import _MockCallableDSL
 from testslide.strict_mock import StrictMock
 
 
-class _PrivateClass(object):
+class _PrivateClass:
     pass
 
 
-class TargetParent(object):
+class TargetParent:
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -32,7 +32,7 @@ class SomeClass:
         return 3
 
 
-class TargetStr(object):
+class TargetStr:
     def __str__(self) -> str:
         return "original response"
 
@@ -94,7 +94,7 @@ class Target(ParentTarget):
         raise RuntimeError("Should not be accessed")
 
 
-class CallOrderTarget(object):
+class CallOrderTarget:
     def __init__(self, name: str) -> None:
         self.name = name
 

--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -34,7 +34,7 @@ def extra_arg_with_wraps(f):
     return wrapper
 
 
-class TemplateParent(object):
+class TemplateParent:
     def __init__(self):
         self.parent_runtime_attr_from_init = True
         self.values = [1, 2, 3]
@@ -143,7 +143,7 @@ class ContextManagerTemplate(Template):
         pass
 
 
-class CallableObject(object):
+class CallableObject:
     def __call__(self):
         pass
 
@@ -709,7 +709,7 @@ def strict_mock(context):
 
                                 @context.example
                                 def can_mock_with_instancemethod(self):
-                                    class SomeClass(object):
+                                    class SomeClass:
                                         def mock_method(self, message):
                                             return "mock: {}".format(message)
 

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -117,7 +117,7 @@ async def _async_ensure_no_leaked_tasks(coro):
     return result
 
 
-class _ContextData(object):
+class _ContextData:
     """
     To be used as a repository of context specific data, used during each
     example execution.
@@ -548,7 +548,7 @@ class _ExampleRunner:
             testslide.patch_attribute.unpatch_all_mocked_attributes()
 
 
-class Example(object):
+class Example:
     """
     Individual example.
     """
@@ -664,7 +664,7 @@ class _TestSlideTestResult(unittest.TestResult):
             self._add_exception(err)  # type: ignore
 
 
-class Context(object):
+class Context:
     """
     Container for example contexts.
     """

--- a/testslide/cli.py
+++ b/testslide/cli.py
@@ -150,7 +150,7 @@ def _load_unittest_test_cases(import_module_names: List[str]) -> None:
 
 
 @dataclass(frozen=True)
-class _Config(object):
+class _Config:
     import_module_names: List[str]
     shuffle: bool
     list: bool
@@ -170,7 +170,7 @@ class _Config(object):
     profile_threshold_ms: Optional[int] = None
 
 
-class Cli(object):
+class Cli:
 
     FORMAT_NAME_TO_FORMATTER_CLASS = {
         "p": ProgressFormatter,

--- a/testslide/dsl.py
+++ b/testslide/dsl.py
@@ -45,7 +45,7 @@ def _require_context(action: str) -> Callable:
     return wrapper
 
 
-class _DSLContext(object):
+class _DSLContext:
     """
     This class implement TestSlide DSL. This is not intended to be used
     directly.

--- a/testslide/import_profiler.py
+++ b/testslide/import_profiler.py
@@ -8,7 +8,7 @@ from types import TracebackType
 from typing import Any, Dict, List, Optional, Tuple
 
 
-class ImportedModule(object):
+class ImportedModule:
     """
     A module that was imported with __import__.
     """
@@ -72,7 +72,7 @@ class ImportedModule(object):
         self.time = time.time() - self._start_time
 
 
-class ImportProfiler(object):
+class ImportProfiler:
     """
     Experimental!
 

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -552,7 +552,7 @@ class _AsyncCallOriginalRunner(_AsyncRunner):
 ##
 
 
-class _CallableMock(object):
+class _CallableMock:
     def __init__(
         self,
         target: Any,
@@ -651,7 +651,7 @@ class _CallableMock(object):
 ##
 
 
-class _MockCallableDSL(object):
+class _MockCallableDSL:
 
     CALLABLE_MOCKS: Dict[
         Union[int, Tuple[int, str]], Union[Callable[[Type[object]], Any]]

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -125,7 +125,7 @@ def _get_original_init(original_class: type, instance: object, owner: type) -> A
         return original_class.__init__.__get__(instance, owner)  # type: ignore
 
 
-class AttrAccessValidation(object):
+class AttrAccessValidation:
     EXCEPTION_MESSAGE = (
         "Attribute {} after the class has been used with mock_constructor() "
         "is not supported! After using mock_constructor() you must get a "

--- a/testslide/patch.py
+++ b/testslide/patch.py
@@ -7,7 +7,7 @@ import inspect
 from typing import Any, Callable, Dict, Optional, Union
 
 
-class _DescriptorProxy(object):
+class _DescriptorProxy:
     def __init__(
         self,
         original_class_attr: Optional[Union[Callable, "_DescriptorProxy"]],

--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -717,7 +717,7 @@ class LongFormatter(
 ##
 
 
-class Runner(object):
+class Runner:
     """
     Execute examples contained in given contexts.
     """

--- a/testslide/strict_mock.py
+++ b/testslide/strict_mock.py
@@ -159,7 +159,7 @@ class _DefaultMagic:
         return self_copy
 
 
-class _MethodProxy(object):
+class _MethodProxy:
     """
     When setting callable attributes, the new value is wrapped by another
     function that does signature and async validations. We then need this proxy
@@ -214,7 +214,7 @@ class _MethodProxy(object):
         return repr(self.__dict__["_value"])
 
 
-class StrictMock(object):
+class StrictMock:
     """
     Mock object that won't allow any attribute access or method call, unless its
     behavior has been explicitly defined. This is meant to be a safer


### PR DESCRIPTION
Differential Revision: D27865017

