### PR TITLE
requirements: relax mypy version dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ coverage
 coveralls
 flake8
 isort~=5.1
-mypy==0.782
+mypy>=0.782
 ipython
 sphinx
 sphinx-autobuild


### PR DESCRIPTION
I don't see anything in TestSlide that would require 0.782 specifically, and this will make it easier to get TestSlide packaged for distributions still stuck on Python 3.6. Also, the new mypy release includes many new features and bug fixes :
http://mypy-lang.blogspot.com/2021/06/mypy-0900-released.html