### PR TITLE
[runner] Use Pattern.search() instead of Pattern.match() for "--filter-regex" behavior

### DIFF
--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -819,7 +819,7 @@ class Runner:
                 return False
 
         if self.names_regex_filter:
-            if not self.names_regex_filter.match(example.full_name):
+            if not self.names_regex_filter.search(example.full_name):
                 return False
 
         return True


### PR DESCRIPTION
See motivation in https://github.com/facebook/TestSlide/issues/305
