### PR TITLE
Allow runtime_attrs to be patched using patch_attribute

### DIFF
--- a/tests/patch_attribute_testslide.py
+++ b/tests/patch_attribute_testslide.py
@@ -194,6 +194,17 @@ def patch_attribute_tests(context):
             context.memoize("target", lambda self: StrictMock())
             context.merge_context("patching works")
 
+        @context.sub_context
+        def with_a_patched_runtime_attr(context):
+            context.memoize(
+                "target",
+                lambda self: StrictMock(
+                    template=sample_module.SomeClass, runtime_attrs=["runtime_attr"]
+                ),
+            )
+            context.memoize("attribute", lambda self: "runtime_attr")
+            context.merge_context("patching works")
+
     @context.example
     def patch_attribute_raises_valueerror_for_private(self):
         with self.assertRaises(ValueError):

--- a/testslide/patch_attribute.py
+++ b/testslide/patch_attribute.py
@@ -63,7 +63,7 @@ def patch_attribute(
         if not type_validation:
             target.__dict__["_attributes_to_skip_type_validation"].append(attribute)
         template_class = target._template
-        if template_class:
+        if template_class and attribute not in target._runtime_attrs:
             value = getattr(template_class, attribute)
             if not isinstance(value, type) and callable(value):
                 raise ValueError(


### PR DESCRIPTION
**What:**

<!-- What changes are being made? (Link the feature request/issue that is being fixed here) -->
Updated `patch_attribute`'s callable patch detection to not run on `StrictMock` `runtime_attrs`.

**Why:**

<!-- Why are these changes necessary? -->
`patch_attribute` doesn't currently work on runtime attributes, as`getattr(template_class, attribute)` will fail.

**How:**

<!-- How were these changes implemented? -->
Adding an additional conditional for `runtime_attrs` to the check for callable detection.

**Risks:**

None that I can think of.

**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
