### PR TITLE
Fix typechecking issue with Python 3.10

### DIFF
--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -312,7 +312,7 @@ class FailurePrinterMixin(ColorFormatterMixin):
         self,
         number: int,
         example: Example,
-        exception: Union[Exception, AggregatedExceptions],
+        exception: Union[Exception, AggregatedExceptions, BaseException],
     ) -> None:
         self.print_bright(
             "  {number}) {context}: {example}".format(


### PR DESCRIPTION
**What:**

Fix a typechecking error when building TestSlide on Python 3.10 that was found in Fedora (https://bugzilla.redhat.com/show_bug.cgi?id=1981718).

**Why:**

```
testslide/runner.py:288: error: Incompatible types in assignment (expression has type "BaseException", variable has type "Union[Exception, AggregatedExceptions]")
Found 1 error in 1 file (checked 26 source files)
make: *** [Makefile:87: mypy] Error 1
```

**How:**

Adding the missing type

**Risks:**

It's typechecking

**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [ ] Added tests, if you've added code that should be tested N/A
- [ ] Updated the documentation, if you've changed APIs N/A
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
