### PR TITLE
allow ignoring all other args in for_call except those specified

### DIFF
--- a/docs/patching/mock_callable/index.rst
+++ b/docs/patching/mock_callable/index.rst
@@ -83,21 +83,6 @@ Note how you get two failed assertions, instead of just one:
 
 It is now pretty clear what is broken, and why it is broken.
 
-For usecases where certain arguments could take many values, and setting up all the for_calls could become tedious you can use ``ignore_other_args`` and ``ignore_other_kwargs``
-This causes Testslide to ignore all validations of args and kwargs passed to the mock, except those that are pinned in the defined for caller_str
-Example:
-.. code-block:: none
-
-def test_ignore_other_args(self):
-    self.mock_callable(sample_module, "test_function", ignore_other_args=True
-    ).for_call("a").to_return_value(["blah"])
-    sample_module.test_function("a", "b")
-
-def test_ignore_other_kwargs(self):
-    self.mock_callable(ample_module, "test_function", ignore_other_kwargs=True
-    ).for_call("firstarg", "secondarg", kwarg1="a").to_return_value(["blah"])
-    sample_module.test_function("firstarg", "secondarg", kwarg1="a", kwarg2="x")
-
 
 
 Defining a Target
@@ -152,6 +137,38 @@ Note how it is **safe by default**: once ``for_call`` is used, other calls will 
 .. note::
 
   Also check :doc:`../argument_matchers/index`: they allow more relaxed argument matching like "any string matching this regexp" or "any positive number".
+
+
+For usecases where certain arguments could take many values, and setting up all the for_calls could become tedious you can use ``for_partial_call``
+This causes Testslide to ignore all validations of args and kwargs passed to the mock, except those that are defined in the  ``for_partial_call``
+
+Tests will still fail, if none of the necessary args or kwargs are passed, so this is a sane golden pathway, between writing safe and easy to use mocks.
+Example:
+
+.. code-block:: none
+
+  def test_for_partial_call_accepts_all_other_args_and_kwargs(self):
+      self.mock_callable(sample_module, "test_function",).for_partial_call(
+          "firstarg", kwarg1="a"
+      ).to_return_value(["blah"])
+      sample_module.test_function("firstarg", "xx", kwarg1="a", kwarg2="x")
+
+  def test_for_partial_call_fails_if_no_required_args_are_present(self):
+      with self.assertRaises(mock_callable.UnexpectedCallArguments):
+          self.mock_callable(sample_module, "test_function",).for_partial_call(
+              "firstarg", kwarg1="a"
+          ).to_return_value(["blah"])
+          sample_module.test_function(
+              "differentarg", "alsodifferent", kwarg1="a", kwarg2="x"
+          )
+
+  def test_for_partial_call_fails_if_no_required_kwargs_are_present(self):
+      with self.assertRaises(mock_callable.UnexpectedCallArguments):
+          self.mock_callable(sample_module, "test_function",).for_partial_call(
+              "firstarg", kwarg1="x"
+          ).to_return_value(["blah"])
+          sample_module.test_function("firstarg", "secondarg", kwarg1="a", kwarg2="x")
+
 
 Composition
 ^^^^^^^^^^^

--- a/docs/patching/mock_callable/index.rst
+++ b/docs/patching/mock_callable/index.rst
@@ -83,6 +83,23 @@ Note how you get two failed assertions, instead of just one:
 
 It is now pretty clear what is broken, and why it is broken.
 
+For usecases where certain arguments could take many values, and setting up all the for_calls could become tedious you can use ``ignore_other_args`` and ``ignore_other_kwargs``
+This causes Testslide to ignore all validations of args and kwargs passed to the mock, except those that are pinned in the defined for caller_str
+Example:
+.. code-block:: none
+
+def test_ignore_other_args(self):
+    self.mock_callable(sample_module, "test_function", ignore_other_args=True
+    ).for_call("a").to_return_value(["blah"])
+    sample_module.test_function("a", "b")
+
+def test_ignore_other_kwargs(self):
+    self.mock_callable(ample_module, "test_function", ignore_other_kwargs=True
+    ).for_call("firstarg", "secondarg", kwarg1="a").to_return_value(["blah"])
+    sample_module.test_function("firstarg", "secondarg", kwarg1="a", kwarg2="x")
+
+
+
 Defining a Target
 -----------------
 

--- a/tests/accept_any_arg_unittest.py
+++ b/tests/accept_any_arg_unittest.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from testslide import TestCase, mock_callable
+from testslide import TestCase, matchers, mock_callable
 
 from . import sample_module
 
@@ -42,3 +42,9 @@ class TestAcceptAnyArg(TestCase):
                 "firstarg", kwarg1="x"
             ).to_return_value(["blah"])
             sample_module.test_function("firstarg", "secondarg", kwarg1="a", kwarg2="x")
+
+    def test_matchers_work_with_for_partial_call(self):
+        self.mock_callable(sample_module, "test_function",).for_partial_call(
+            matchers.Any(), "secondarg"
+        ).to_return_value(["blah"])
+        sample_module.test_function("asdasdeas", "secondarg", kwarg1="a", kwarg2="x")

--- a/tests/accept_any_arg_unittest.py
+++ b/tests/accept_any_arg_unittest.py
@@ -1,0 +1,26 @@
+from testslide import TestCase
+
+from . import sample_module
+
+
+class TestAcceptAnyArg(TestCase):
+    def test_ignore_other_args(self):
+        self.mock_callable(
+            sample_module, "test_function", ignore_other_args=True
+        ).for_call("a").to_return_value(["blah"])
+        sample_module.test_function("a", "b")
+
+    def test_ignore_other_kwargs(self):
+        self.mock_callable(
+            sample_module, "test_function", ignore_other_kwargs=True
+        ).for_call("firstarg", "secondarg", kwarg1="a").to_return_value(["blah"])
+        sample_module.test_function("firstarg", "secondarg", kwarg1="a", kwarg2="x")
+
+    def test_ignore_other_args_and_kwargs(self):
+        self.mock_callable(
+            sample_module,
+            "test_function",
+            ignore_other_args=True,
+            ignore_other_kwargs=True,
+        ).for_call("firstarg", kwarg1="a").to_return_value(["blah"])
+        sample_module.test_function("firstarg", "xx", kwarg1="a", kwarg2="x")

--- a/tests/accept_any_arg_unittest.py
+++ b/tests/accept_any_arg_unittest.py
@@ -1,26 +1,44 @@
-from testslide import TestCase
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from testslide import TestCase, mock_callable
 
 from . import sample_module
 
 
 class TestAcceptAnyArg(TestCase):
-    def test_ignore_other_args(self):
-        self.mock_callable(
-            sample_module, "test_function", ignore_other_args=True
-        ).for_call("a").to_return_value(["blah"])
+    def test_for_partial_call_accepts_all_other_args(self):
+        self.mock_callable(sample_module, "test_function").for_partial_call(
+            "a"
+        ).to_return_value(["blah"])
         sample_module.test_function("a", "b")
 
-    def test_ignore_other_kwargs(self):
-        self.mock_callable(
-            sample_module, "test_function", ignore_other_kwargs=True
-        ).for_call("firstarg", "secondarg", kwarg1="a").to_return_value(["blah"])
+    def test_for_partial_call_accepts_all_other_kwargs(self):
+        self.mock_callable(sample_module, "test_function").for_partial_call(
+            "firstarg", "secondarg", kwarg1="a"
+        ).to_return_value(["blah"])
         sample_module.test_function("firstarg", "secondarg", kwarg1="a", kwarg2="x")
 
-    def test_ignore_other_args_and_kwargs(self):
-        self.mock_callable(
-            sample_module,
-            "test_function",
-            ignore_other_args=True,
-            ignore_other_kwargs=True,
-        ).for_call("firstarg", kwarg1="a").to_return_value(["blah"])
+    def test_for_partial_call_accepts_all_other_args_and_kwargs(self):
+        self.mock_callable(sample_module, "test_function",).for_partial_call(
+            "firstarg", kwarg1="a"
+        ).to_return_value(["blah"])
         sample_module.test_function("firstarg", "xx", kwarg1="a", kwarg2="x")
+
+    def test_for_partial_call_fails_if_no_required_args_are_present(self):
+        with self.assertRaises(mock_callable.UnexpectedCallArguments):
+            self.mock_callable(sample_module, "test_function",).for_partial_call(
+                "firstarg", kwarg1="a"
+            ).to_return_value(["blah"])
+            sample_module.test_function(
+                "differentarg", "alsodifferent", kwarg1="a", kwarg2="x"
+            )
+
+    def test_for_partial_call_fails_if_no_required_kwargs_are_present(self):
+        with self.assertRaises(mock_callable.UnexpectedCallArguments):
+            self.mock_callable(sample_module, "test_function",).for_partial_call(
+                "firstarg", kwarg1="x"
+            ).to_return_value(["blah"])
+            sample_module.test_function("firstarg", "secondarg", kwarg1="a", kwarg2="x")

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -271,7 +271,9 @@ class _BaseRunner:
     def can_accept_args(self, *args: Any, **kwargs: Any) -> bool:
         if self.accepted_args:
             if self._accept_partial_call:
-                args_match = all(elem in args for elem in self.accepted_args[0])
+                args_match = all(
+                    any(elem == arg for arg in args) for elem in self.accepted_args[0]
+                )
                 kwargs_match = all(
                     elem in kwargs.keys()
                     and kwargs[elem] == self.accepted_args[1][elem]


### PR DESCRIPTION

**What:**
Allow asserting only some call arguments as requested 

**Why:**
Feature request


**How:**

Add new argument ``ignore_other_args`` and ``ignore_other_kwargs`` for mock_callable and mock_async_callable
Change get base_runner.can_accept_args to return True if provided args match, if any of the switches provided
**Risks:**

**Checklist**:



- [X] Added tests, if you've added code that should be tested
- [X] Updated the documentation, if you've changed APIs
- [X] Ensured the test suite passes
- [X] Made sure your code lints
- [X] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
