### PR TITLE
Removal of Union of BaseException and it's subclasses

### DIFF
--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -259,10 +259,10 @@ class AggregatedExceptions(Exception):
 
     def __init__(self) -> None:
         super(AggregatedExceptions, self).__init__()
-        self.exceptions: List[Union[Exception, BaseException]] = []
+        self.exceptions: List[BaseException] = []
 
     def append_exception(
-        self, exception: Union[Exception, "AggregatedExceptions", BaseException]
+        self, exception: BaseException
     ) -> None:
         if isinstance(exception, AggregatedExceptions):
             self.exceptions.extend(exception.exceptions)
@@ -605,8 +605,8 @@ class _TestSlideTestResult(unittest.TestResult):
     def _add_exception(
         self,
         err: Tuple[
-            Union[Type[Exception], Type[BaseException]],
-            Union[Exception, BaseException],
+            Type[BaseException],
+            BaseException,
             Optional[types.TracebackType],
         ],
     ) -> None:
@@ -617,8 +617,8 @@ class _TestSlideTestResult(unittest.TestResult):
         self,
         test: "TestCase",
         err: Tuple[
-            Union[Type[Exception], Type[BaseException]],
-            Union[Exception, BaseException],
+            Type[BaseException],
+            BaseException,
             types.TracebackType,
         ],
     ) -> None:
@@ -632,8 +632,8 @@ class _TestSlideTestResult(unittest.TestResult):
         self,
         test: "TestCase",
         err: Tuple[
-            Union[Type[Exception], Type[BaseException]],
-            Union[Exception, BaseException],
+            Type[BaseException],
+            BaseException,
             types.TracebackType,
         ],
     ) -> None:
@@ -654,7 +654,7 @@ class _TestSlideTestResult(unittest.TestResult):
         super(_TestSlideTestResult, self).addUnexpectedSuccess(test)
         self._add_exception((type(UnexpectedSuccess), UnexpectedSuccess(), None))  # type: ignore
 
-    def addSubTest(self, test: "TestCase", subtest: "TestCase", err: Tuple[Optional[Union[Type[Exception], Type[BaseException]]], Optional[Union[Exception, BaseException]], Optional[types.TracebackType]]) -> None:  # type: ignore
+    def addSubTest(self, test: "TestCase", subtest: "TestCase", err: Tuple[Optional[Type[BaseException]], Optional[BaseException], Optional[types.TracebackType]]) -> None:  # type: ignore
         """Called at the end of a subtest.
         'err' is None if the subtest ended successfully, otherwise it's a
         tuple of values as returned by sys.exc_info().

--- a/testslide/__init__.py
+++ b/testslide/__init__.py
@@ -261,9 +261,7 @@ class AggregatedExceptions(Exception):
         super(AggregatedExceptions, self).__init__()
         self.exceptions: List[BaseException] = []
 
-    def append_exception(
-        self, exception: BaseException
-    ) -> None:
+    def append_exception(self, exception: BaseException) -> None:
         if isinstance(exception, AggregatedExceptions):
             self.exceptions.extend(exception.exceptions)
         else:

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -482,7 +482,7 @@ class _RaiseRunner(_Runner):
         target: Union[type, str],
         method: str,
         original_callable: Union[Callable[..., Any], Mock],
-        exception: Union[Exception, BaseException],
+        exception: BaseException,
     ) -> None:
         super(_RaiseRunner, self).__init__(target, method, original_callable)
         self.exception = exception

--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -312,7 +312,7 @@ class FailurePrinterMixin(ColorFormatterMixin):
         self,
         number: int,
         example: Example,
-        exception: Union[Exception, AggregatedExceptions, BaseException],
+        exception: BaseException,
     ) -> None:
         self.print_bright(
             "  {number}) {context}: {example}".format(


### PR DESCRIPTION
<!-- 
Thank you for your interest in this project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct of this project which can be found at https://github.com/facebookincubator/TestSlide/blob/master/CODE_OF_CONDUCT.md 

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines which can  be found at https://github.com/facebookincubator/TestSlide/blob/master/CONTRIBUTING.md

-->

**What:**
https://github.com/facebook/TestSlide/issues/248
<!-- What changes are being made? (Link the feature request/issue that is being fixed here) -->

**Why:**
Simplifying type hints by removal of subclasses of BaseExceptions.
<!-- Why are these changes necessary? -->

**How:**

<!-- How were these changes implemented? -->

**Risks:**

<!-- Any possible risks you've likely introduced in this PR?  -->

**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
