### PR TITLE
Use more specific callable types in DSL hooks

### DIFF
--- a/testslide/dsl.py
+++ b/testslide/dsl.py
@@ -7,16 +7,19 @@ import functools
 import inspect
 from functools import partial
 from re import sub as _sub
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, Union, NoReturn
 
 from testslide import Context, TestCase
 
-from . import Context as _Context
+from . import Context as _Context, _ContextData
 from . import Skip  # noqa: F401
 
 
+ExampleFunction = Callable[[_ContextData], None]
+
+
 def _validate_parameter(
-    code: Callable, name: str, index: int, allow_async: bool = True
+    code: ExampleFunction, name: str, index: int, allow_async: bool = True
 ) -> None:
     parameters = list(inspect.signature(code).parameters.keys())
     if not parameters or parameters[index] != name:
@@ -62,16 +65,16 @@ class _DSLContext:
         self.focus = focus
 
     @staticmethod
-    def _not_callable(*args: Any, **kwargs: Any) -> None:
+    def _not_callable(*args: Any, **kwargs: Any) -> NoReturn:
         raise BaseException("This function should not be called outside test code.")
 
     @staticmethod
-    def _name_from_function(func: Callable) -> str:
+    def _name_from_function(func: ExampleFunction) -> str:
         return _sub("_", " ", func.__name__)
 
     def _create_context(
-        self, name: str, context_code: Callable, *args: Any, **kwargs: Any
-    ) -> Callable:
+        self, name: str, context_code: ExampleFunction, *args: Any, **kwargs: Any
+    ) -> NoReturn:
         if not self.current_context:
             new_context = _Context(name, skip=self.skip, focus=self.focus)
         else:
@@ -86,7 +89,7 @@ class _DSLContext:
         )
         return self._not_callable
 
-    def __call__(self, arg: Union[str, Callable]) -> Union[partial, Callable]:
+    def __call__(self, arg: Union[str, ExampleFunction]) -> Union[partial, NoReturn]:
         if callable(arg):
             context_code = arg
             name = self._name_from_function(context_code)
@@ -101,16 +104,16 @@ class _DSLContext:
 
     # nested contexts
 
-    def sub_context(self, arg: Union[str, Callable]) -> Union[partial, Callable]:
+    def sub_context(self, arg: Union[str, ExampleFunction]) -> Union[partial, NoReturn]:
         self._reset()
         return self(arg)
 
-    def xsub_context(self, arg: Callable) -> Callable:
+    def xsub_context(self, arg: ExampleFunction) -> NoReturn:
         self._reset()
         self.skip = True
         return self(arg)
 
-    def fsub_context(self, arg: Callable) -> Callable:
+    def fsub_context(self, arg: ExampleFunction) -> NoReturn:
         self._reset()
         self.focus = True
         return self(arg)
@@ -119,8 +122,8 @@ class _DSLContext:
 
     @_require_context("create example")
     def _create_example(
-        self, name: Optional[str], example_code: Callable, skip: bool, focus: bool
-    ) -> Callable:
+        self, name: Optional[str], example_code: ExampleFunction, skip: bool, focus: bool
+    ) -> NoReturn:
         if name is None:
             name = self._name_from_function(example_code)
         _validate_parameter(example_code, "self", 0)
@@ -129,11 +132,11 @@ class _DSLContext:
 
     def example(
         self,
-        arg: Optional[Union[str, Callable]] = None,
+        arg: Optional[Union[str, ExampleFunction]] = None,
         skip: bool = False,
         focus: bool = False,
         skip_unless: bool = True,
-    ) -> Union[partial, Callable]:
+    ) -> Union[partial, NoReturn]:
         skip = skip or not skip_unless
         if callable(arg):
             example_code = arg
@@ -143,23 +146,23 @@ class _DSLContext:
             name = arg  # type: ignore
             return functools.partial(self._create_example, name, skip=skip, focus=focus)
 
-    def xexample(self, arg: Union[str, Callable]) -> Callable:
+    def xexample(self, arg: Union[str, ExampleFunction]) -> NoReturn:
         return self.example(arg, skip=True)
 
-    def fexample(self, arg: Union[str, Callable]) -> Callable:
+    def fexample(self, arg: Union[str, ExampleFunction]) -> NoReturn:
         return self.example(arg, focus=True)
 
     # Shared contexts
 
     @_require_context("create a shared context")
     def _create_shared_context(
-        self, name: str, shared_context_code: Callable
-    ) -> Callable:
+        self, name: str, shared_context_code: ExampleFunction
+    ) -> NoReturn:
         _validate_parameter(shared_context_code, "context", 0)
         self.current_context.add_shared_context(name, shared_context_code)  # type: ignore
         return self._not_callable
 
-    def shared_context(self, arg: Union[str, Callable]) -> Union[partial, Callable]:
+    def shared_context(self, arg: Union[str, ExampleFunction]) -> Union[partial, NoReturn]:
         if callable(arg):
             shared_context_code = arg
             name = self._name_from_function(shared_context_code)
@@ -175,7 +178,7 @@ class _DSLContext:
         self.current_context.all_shared_contexts[name](self, *args, **kwargs)  # type: ignore
 
     @_require_context("merge a TestCase")
-    def merge_test_case(self, test_case: "TestCase", attr_name: str) -> Callable:
+    def merge_test_case(self, test_case: "TestCase", attr_name: str) -> NoReturn:
         self.current_context.add_test_case(test_case, attr_name)  # type:ignore
         return self._not_callable
 
@@ -190,7 +193,7 @@ class _DSLContext:
     # Helper function
 
     @_require_context("create functions")
-    def function(self, function_code: Callable) -> Callable:
+    def function(self, function_code: ExampleFunction) -> NoReturn:
         _validate_parameter(function_code, "self", 0)
         self.current_context.add_function(function_code.__name__, function_code)  # type: ignore
         return self._not_callable
@@ -200,11 +203,11 @@ class _DSLContext:
     @_require_context("create memoizable attributes")
     def memoize(
         self,
-        name_or_code: Optional[Union[str, Callable]] = None,
-        memoizable_code: Optional[Callable] = None,
+        name_or_code: Optional[Union[str, ExampleFunction]] = None,
+        memoizable_code: Optional[ExampleFunction] = None,
         **kwargs: Any,
-    ) -> Callable:
-        _memoizable_code: Callable
+    ) -> NoReturn:
+        _memoizable_code: ExampleFunction
         if name_or_code:
             if kwargs:
                 raise ValueError("Invalid arguments!")
@@ -226,10 +229,10 @@ class _DSLContext:
     @_require_context("create a memoize before attribute")
     def memoize_before(
         self,
-        name_or_code: Union[str, Callable],
-        memoizable_code: Optional[Callable] = None,
-    ) -> Callable:
-        _memoizable_code: Callable
+        name_or_code: Union[str, ExampleFunction],
+        memoizable_code: Optional[ExampleFunction] = None,
+    ) -> NoReturn:
+        _memoizable_code: ExampleFunction
         if memoizable_code:  # Got a lambda
             name = name_or_code
             _memoizable_code = memoizable_code
@@ -246,7 +249,7 @@ class _DSLContext:
     # Hooks
 
     @_require_context("register before hook")
-    def before(self, before_code: Callable) -> Callable:
+    def before(self, before_code: ExampleFunction) -> NoReturn:
         _validate_parameter(before_code, "self", 0)
         if not self.current_context:
             raise TypeError("Can not register before hook at top level context")
@@ -254,13 +257,13 @@ class _DSLContext:
         return self._not_callable
 
     @_require_context("register after hook")
-    def after(self, after_code: Callable) -> Callable:
+    def after(self, after_code: ExampleFunction) -> NoReturn:
         _validate_parameter(after_code, "self", 0)
         self.current_context.after_functions.append(after_code)  # type: ignore
         return self._not_callable
 
     @_require_context("register around hook")
-    def around(self, around_code: Callable) -> Callable:
+    def around(self, around_code: ExampleFunction) -> NoReturn:
         _validate_parameter(around_code, "self", 0)
         _validate_parameter(around_code, "wrapped", 1)
         if not self.current_context:


### PR DESCRIPTION
<!--
Thank you for your interest in this project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct of this project which can be found at https://github.com/facebook/TestSlide/blob/main/CODE_OF_CONDUCT.md

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines which can  be found at https://github.com/facebook/TestSlide/blob/main/CONTRIBUTING.md

-->

**What:**

Adding more accurate type hints than simply using `Callable` everywhere. 

**Why:**

Because... accurate typing is a Good Thing(tm).

**How:**

Using `NoReturn` from `typing` module and creating a type alias `ExampleFunction` with a full type-signature to be used in all of the hooks around examples.

**Risks:**

Test continue to pass :-)

**Checklist**:

<!--
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [ ] Added tests, if you've added code that should be tested (N/A)
- [ ] Updated the documentation, if you've changed APIs (N/A)
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")

