### PR TITLE
Fix sync functions with `Awaitable[...]` or `Coroutine[...]` return annotation failing to be mocked with `mock_async_callable(..., callable_returns_coroutine=True)` due to TypeCheckError

### DIFF
--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Awaitable, Coroutine, Dict, List, Optional, Tuple, Union
 
 attribute = "value"
 typedattr: str = "bruh"
@@ -114,12 +114,25 @@ def test_function(
     "This function is used by some unit tests only"
     return ["original response"]
 
-
 async def async_test_function(
     arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
 ) -> List[str]:
     "This function is used by some unit tests only"
     return ["original response"]
+
+
+def test_function_returns_awaitable(
+    arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
+) -> Awaitable[List[str]]:
+    "This function is used by some unit tests only"
+    return async_test_function(arg1, arg2, kwarg1, kwarg2)
+
+
+def test_function_returns_coroutine(
+    arg1: str, arg2: str, kwarg1: str = "", kwarg2: str = ""
+) -> Coroutine[Any, Any, List[str]]:
+    "This function is used by some unit tests only"
+    return async_test_function(arg1, arg2, kwarg1, kwarg2)
 
 
 UnionArgType = Dict[str, Union[str, int]]

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -574,6 +574,7 @@ class _CallableMock:
         method: str,
         caller_frame_info: Traceback,
         is_async: bool = False,
+        callable_returns_coroutine: bool = False,
         # type_validation accepted values:
         #  * None:  type validation will be enabled except if target is a StrictMock
         #           with disabled type validation
@@ -585,6 +586,7 @@ class _CallableMock:
         self.method = method
         self.runners: List[_BaseRunner] = []
         self.is_async = is_async
+        self.callable_returns_coroutine = callable_returns_coroutine
         self.type_validation = type_validation or type_validation is None
         self.caller_frame_info = caller_frame_info
 
@@ -604,7 +606,10 @@ class _CallableMock:
         if self.type_validation and runner.TYPE_VALIDATION:
             if runner.original_callable is not None:
                 _validate_return_type(
-                    runner.original_callable, value, self.caller_frame_info
+                    runner.original_callable,
+                    value,
+                    self.caller_frame_info,
+                    self.callable_returns_coroutine,
                 )
             elif isinstance(runner.target, StrictMock):
                 _validate_return_type(
@@ -1189,6 +1194,7 @@ class _MockAsyncCallableDSL(_MockCallableDSL):
             self._method,
             self.caller_frame_info,
             is_async=True,
+            callable_returns_coroutine=self._callable_returns_coroutine,
             type_validation=self.type_validation,
         )
 


### PR DESCRIPTION
Summary: Fixes https://github.com/facebook/TestSlide/issues/323.

Differential Revision: D33064177

