### PR TITLE
Use repr for mock_callable's formatting of kwargs

### DIFF
--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -123,7 +123,7 @@ def mock_callable_tests(context):
                 kwargs_msg = (
                     "    {\n"
                     + "".join(
-                        "      {}={},\n".format(k, self.call_kwargs[k])
+                        "      {}={},\n".format(k, repr(self.call_kwargs[k]))
                         for k in sorted(self.call_kwargs.keys())
                     )
                     + "    }\n"
@@ -251,7 +251,7 @@ def mock_callable_tests(context):
                                 + "    {\n"
                                 + "".join(
                                     "      {}={},\n".format(
-                                        k, self.specific_call_kwargs[k]
+                                        k, repr(self.specific_call_kwargs[k])
                                     )
                                     for k in sorted(self.specific_call_kwargs.keys())
                                 )

--- a/testslide/mock_callable.py
+++ b/testslide/mock_callable.py
@@ -145,7 +145,7 @@ def _format_args(indent: int, *args: Any, **kwargs: Any) -> str:
         if kwargs:
             s += "\n"
             for k in sorted(kwargs.keys()):
-                s += "{}  {}={},\n".format(indentation, k, kwargs[k])
+                s += "{}  {}={},\n".format(indentation, k, repr(kwargs[k]))
             s += "{}".format(indentation)
         s += "}\n"
     return s


### PR DESCRIPTION
**What:**

<!-- What changes are being made? (Link the feature request/issue that is being fixed here) -->
Updated mock_callable.py's `_format_args` to use repr for formatting kwargs of registered/received calls.

**Why:**

<!-- Why are these changes necessary? -->
Not using repr makes the formatting between args and kwargs different and makes debugging test cases more difficult in certain cases. For example figuring out the type mismatch between the registered vs received call for `bar`:
```
def foo():
    bar(baz="1")
    ...


def bar(baz):
    ...
```

```
class Test(TestCase):
    def test_foo(self):
        self.mock_callable(BASE_MODULE, "bar").for_call(baz=1).to_return_value(None)
        foo()
```

Before
```
    1) UnexpectedCallArguments:
      Received call:
        {
          baz=1,
        }
      But no behavior was defined for it.
      These are the registered calls:
        {
          baz=1,
        }
```

After
```
    1) UnexpectedCallArguments:
      Received call:
        {
          baz='1',
        }
      But no behavior was defined for it.
      These are the registered calls:
        {
          baz=1,
        }
```

**How:**

<!-- How were these changes implemented? -->
Calling `repr()` on mock_callable's registered/received kwargs.

**Risks:**

None that I can think of.

**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
