### PR TITLE
Run pytest with --asyncio-mode=auto

### DIFF
--- a/pytest-testslide/tests/test_pytest_testslide.py
+++ b/pytest-testslide/tests/test_pytest_testslide.py
@@ -125,7 +125,7 @@ def test_pass(testdir):
             sample_module.CallOrderTarget("c").f1("a")
         """
     )
-    result = testdir.runpytest("-v")
+    result = testdir.runpytest("-v", "--asyncio-mode=auto")
     assert "passed, 4 errors" in result.stdout.str()
     assert "failed" not in result.stdout.str()
     expected_failure = re.compile(


### PR DESCRIPTION
**What:**

<!-- What changes are being made? (Link the feature request/issue that is being fixed here) -->
Updated call to `runpytest` to use `--asyncio-mode=auto`.

**Why:**

<!-- Why are these changes necessary? -->
[Pytest tests are currently failing](https://github.com/facebook/TestSlide/runs/5406260148?check_suite_focus=true) due to the deprecation warning added to pytest-asyncio in https://github.com/pytest-dev/pytest-asyncio/commit/0a143c4356eb121e7ad44fa1f1fbe1a52e7e3a33 causing the assertion https://github.com/facebook/TestSlide/blob/55f12e60010233ee393a71270135170400662c6b/pytest-testslide/tests/test_pytest_testslide.py#L129 to fail, as the output now contains `23 passed, 1 warning, 4 errors in x.xxs`. 

Based on https://github.com/pytest-dev/pytest-asyncio#modes I think auto is the correct mode, please let me know if it should be something else.
**How:**

<!-- How were these changes implemented? -->
Adding `--asyncio-mode=auto` to the pytest run.

**Risks:**

None that I can think of.

**Checklist**:

<!-- 
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
