### PR TITLE
Fix tests for Python3.6 by removing asyncio-mode as it's not supported.

### DIFF
--- a/pytest-testslide/tests/test_pytest_testslide.py
+++ b/pytest-testslide/tests/test_pytest_testslide.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import re
+import sys
 
 
 def test_pass(testdir):
@@ -125,7 +126,11 @@ def test_pass(testdir):
             sample_module.CallOrderTarget("c").f1("a")
         """
     )
-    result = testdir.runpytest("-v", "--asyncio-mode=auto")
+    # asyncio-mode is not supported on python3.6
+    if sys.version_info >= (3, 7):
+        result = testdir.runpytest("-v", "--asyncio-mode=auto")
+    else:
+        result = testdir.runpytest("-v")
     assert "passed, 4 errors" in result.stdout.str()
     assert "failed" not in result.stdout.str()
     expected_failure = re.compile(


### PR DESCRIPTION
**What:**

CI tests are currently [failing](https://github.com/facebook/TestSlide/actions/runs/2158772378) for Python3.6 with the error:

```
ERROR: usage: __main__.py [options] [file_or_dir] [file_or_dir] [...]
__main__.py: error: unrecognized arguments: --asyncio-mode=auto
  inifile: None
```

**Why:**

CI/unit tests are failing for Python3.6.
I believe this failure was introduced with [this](https://github.com/facebook/TestSlide/pull/328) change and [pytest-asyncio](https://github.com/pytest-dev/pytest-asyncio) seems to be 3.7+ compatible.


**How:**

Do not run pytest with `--asyncio-mode=auto` for Python3.6

**Risks:**

None identified.

**Checklist**:


- [ ] Added tests, if you've added code that should be tested (N/A)
- [ ] Updated the documentation, if you've changed APIs( N/A)
- [X] Ensured the test suite passes
- [X] Made sure your code lints
- [X] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
