### PR TITLE
Speed up mock_constructor by removing gc.collect

### DIFF
--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -349,7 +349,6 @@ def mock_constructor(
                 "Usage with classes that define __new__() is currently not supported."
             )
 
-        gc.collect()
         instances = [
             obj
             for obj in gc.get_referrers(original_class)


### PR DESCRIPTION
Summary:
mock_aiog
0:00:00.064367
from this calling gc.collect took:
0:00:00.053297 and it's _synchronous_

since default slow callback detection is 0.1 if someone uses multiple mock_constructor calls these gc.collect-s add up and exceed the threshold

Differential Revision: D38073077

