### PR TITLE
Remove mock_constructor check for existing instances, as removing gc.collect made it unstable

### DIFF
--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -167,19 +167,6 @@ def mock_constructor(context):
     @context.sub_context
     def patching_mechanism(context):
         @context.example
-        def can_not_mock_constructor_with_existing_instances(self):
-            original_target = original_target_class()
-            with self.assertRaisesWithMessageInException(
-                RuntimeError,
-                "mock_constructor() can not be used after instances of Target were created: {}".format(
-                    [original_target]
-                ),
-            ):
-                self.mock_constructor(
-                    self.target_module, self.target_class_name
-                ).to_call_original()
-
-        @context.example
         def works_with_composition(self):
             self.mock_constructor(self.target_module, self.target_class_name).for_call(
                 "1"
@@ -233,15 +220,6 @@ def mock_constructor(context):
 
     @context.sub_context
     def arguments(context):
-        @context.example
-        def refuses_to_mock_if_instances_exist(self):
-            target_instance = self.get_target_class()()  # noqa F841
-            with self.assertRaisesWithMessageInException(
-                RuntimeError,
-                "mock_constructor() can not be used after instances of Target were created: ",
-            ):
-                self.mock_constructor(self.target_module, self.target_class_name)
-
         @context.sub_context
         def module(context):
             context.memoize("args", lambda self: ("6", "7"))

--- a/testslide/mock_constructor.py
+++ b/testslide/mock_constructor.py
@@ -2,8 +2,6 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
-import gc
 import inspect
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
@@ -347,18 +345,6 @@ def mock_constructor(
         if "__new__" in original_class.__dict__:
             raise NotImplementedError(
                 "Usage with classes that define __new__() is currently not supported."
-            )
-
-        instances = [
-            obj
-            for obj in gc.get_referrers(original_class)
-            if type(obj) is original_class
-        ]
-        if instances:
-            raise RuntimeError(
-                "mock_constructor() can not be used after instances of {} were created: {}".format(
-                    class_name, instances
-                )
             )
 
         if not inspect.isclass(original_class):


### PR DESCRIPTION
Summary: Certain weird usecases would require us to call gc.collect(), but that makes the eventloop , so is not a good option. This is a good enough compromise

Differential Revision: D38455488

