### PR TITLE
Mypy upgrade from 0.782 to 0.991

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ release = version
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ["IPython.sphinxext.ipython_console_highlighting"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ coverage
 coveralls
 flake8
 isort~=5.1
-mypy==0.782
+mypy==0.991
 ipython
 sphinx
 sphinx-autobuild

--- a/tests/copyright_check/config.py
+++ b/tests/copyright_check/config.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
+from typing import List
 
 debug_logs = False
 
@@ -12,7 +13,7 @@ rootdir = Path(__file__).parent.parent.absolute()
 default_check_dir = rootdir / "copyright_check"
 
 # if want to run specific files, add to this list
-filelist = []
+filelist: List[str] = []
 
 # If we want to ignore, add directories in ignore_dirs
-ignore_dirs = []
+ignore_dirs: List[str] = []

--- a/tests/copyright_check/copyright_validator.py
+++ b/tests/copyright_check/copyright_validator.py
@@ -13,7 +13,7 @@ import pathlib
 import re
 import sys
 
-import config
+import config  # type: ignore[import]
 
 
 def print_logs(*args, **kwargs):

--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -357,7 +357,7 @@ def _validate_return_type(context):
         https://github.com/facebook/TestSlide/issues/165
         """
 
-        def with_typevar_return() -> Type[TypeVar("T")]:
+        def with_typevar_return() -> Type[TypeVar("T")]:  # type: ignore[empty-body]
             pass
 
         self.callable_template = with_typevar_return

--- a/tests/pep487_unittest.py
+++ b/tests/pep487_unittest.py
@@ -7,6 +7,7 @@ import sys
 
 import testslide
 
+
 class QuestBase:
     def __init_subclass__(cls, swallow, **kwargs):
         cls.swallow = swallow

--- a/testslide/cli.py
+++ b/testslide/cli.py
@@ -41,8 +41,8 @@ def _filename_to_module_name(name: str) -> str:
 def _get_all_test_case_subclasses() -> List[TestCase]:
     def get_all_subclasses(base: Type[unittest.TestCase]) -> List[TestCase]:
         return list(
-            {  # type: ignore
-                "{}.{}".format(c.__module__, c.__name__): c
+            {  # type: ignore[arg-type]
+                "{}.{}".format(c.__module__, c.__name__): c  # type: ignore
                 for c in (
                     base.__subclasses__()  # type: ignore
                     + [g for s in base.__subclasses__() for g in get_all_subclasses(s)]  # type: ignore
@@ -386,7 +386,10 @@ class Cli:
         try:
             parsed_args = self.parser.parse_args(self.args)
         except SystemExit as e:
-            return e.code
+            # Basically, argparse has a `.error()` method that calls a `.exit()` method,
+            # which in turn calls `sys.exit()`, passing an int parameter.
+            # Ignore the detection that it might be a None or str.
+            return e.code  # type: ignore
         config = self._get_config_from_parsed_args(parsed_args)
 
         if config.profile_threshold_ms is not None:

--- a/testslide/import_profiler.py
+++ b/testslide/import_profiler.py
@@ -115,8 +115,8 @@ class ImportProfiler:
     def _profiled_import(
         self,
         name: str,
-        globals: Dict[str, Any] = None,
-        locals: Dict[str, Any] = None,
+        globals: Optional[Dict[str, Any]] = None,
+        locals: Optional[Dict[str, Any]] = None,
         fromlist: Tuple = (),
         level: int = 0,
     ) -> None:

--- a/testslide/runner.py
+++ b/testslide/runner.py
@@ -766,7 +766,7 @@ class Runner:
         contexts: List[Context],
         formatter: Union[SlowImportWarningMixin, DocumentFormatter],
         shuffle: bool = False,
-        seed: int = None,
+        seed: Optional[int] = None,
         focus: bool = False,
         fail_fast: bool = False,
         fail_if_focused: bool = False,


### PR DESCRIPTION
<!--
Thank you for your interest in this project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct of this project which can be found at https://github.com/facebook/TestSlide/blob/main/CODE_OF_CONDUCT.md

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines which can  be found at https://github.com/facebook/TestSlide/blob/main/CONTRIBUTING.md

-->

**What:**
mypy is currently pinned on an old version, and type checks are currently breaking the tests.

**Why:**

I saw a comment somewhere about avoiding type checker pain by upgrading, and decided to face the pain.

A side-effect is that the type check that is currently broken around the arguments to `type()` got fixed just by upgrading.

**How:**

Review needed. In several cases I'm adding more ignores, because I cannot see a simple resolution.

Fixed a lexer issue for Pygments by adding the extension in the Sphinx config file.



**Risks:**

Tests are passing.

Biggest change is in the frame checking code in `mock_constructor.py` - if a caller frame can't be found, then the previous one can't be found, and the attempt to get frame info to set up the `_CallableMock` would probably fail? I can't see how this would happen in reality, but using type refinement made mypy happy. 

If someone can come up with a test case that would generate a None for the currentframe() call, I'll add it and test it.

**Checklist**:

- [ ] Added tests, if you've added code that should be tested (Unsure if needed)
- [ ] Updated the documentation, if you've changed APIs N/A
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")