### PR TITLE
Fix default_context_manager in conjunction with ExitStack.

### DIFF
--- a/tests/strict_mock_testslide.py
+++ b/tests/strict_mock_testslide.py
@@ -814,6 +814,14 @@ def strict_mock(context):
                                     with self.strict_mock as target:
                                         self.assertTrue(target is self.strict_mock)
 
+                                @context.example
+                                def works_with_exitstack(self):
+                                    with contextlib.ExitStack() as exit_stack:
+                                        target = exit_stack.enter_context(
+                                            self.strict_mock
+                                        )
+                                        self.assertTrue(target is self.strict_mock)
+
             @context.sub_context
             def string_template(context):
                 @context.example
@@ -1115,6 +1123,14 @@ def strict_mock(context):
                         async def it_yields_the_mock(self):
                             async with self.strict_mock as m:
                                 assert id(self.strict_mock) == id(m)
+
+                        @context.example
+                        async def works_with_exitstack(self):
+                            async with contextlib.AsyncExitStack() as exit_stack:
+                                target = await exit_stack.enter_async_context(
+                                    self.strict_mock
+                                )
+                                self.assertTrue(target is self.strict_mock)
 
     @context.sub_context
     def making_copies(context):


### PR DESCRIPTION
Summary:
As outlined in the comment; because our MethodProxy objects don't get bound to
the object (via __get__); when (Async)ExitStack comes along and invokes:

```
enter_fn = cm.__class_.__enter__
enter_fn(cm)
```

A problem occurs - while the attribute lookup succeeds (yay); it's not
expecting a `self` paramter explicitly passed here, as it's not a bound python
method.

Theoretically; magic could be added to MethodProxy to properly bind via
`__get__`, but my knowledge of testslide right now isn't strong enough to feel
confident in that approach, so I'm opting for this.

Differential Revision: D42114206

