### PR TITLE
Collection matchers

### DIFF
--- a/docs/patching/argument_matchers/index.rst
+++ b/docs/patching/argument_matchers/index.rst
@@ -101,6 +101,18 @@ Dictionaries
 	"``DictContainingKeys(keys_list)``", "A dictionary containing all keys from ``keys_list``"
 	"``DictSupersetOf(this_dict)``", "A dictionary containing all key / value pairs from ``this_dict``"
 
+Containers and Iterables
+------------------------
+.. csv-table::
+	:header: "Matcher", "Description"
+
+	"``AnyContaining(element)``", "Any container that contains ``element``"
+	"``AnyContainingAll(element_list)``", "Any container that contains every element of ``element_list``"
+	"``AnyIterable()``", "Any iterable"
+	"``AnyIterableWithElements(element_list)``", "Any iterable containing all the elements in ``element_list`` in the same order"
+	"``NotEmptyIterable()``", "An iterable with at least one element"
+	"``EmptyIterable()``", "An empty iterable"
+
 Generic
 -------
 

--- a/docs/patching/argument_matchers/index.rst
+++ b/docs/patching/argument_matchers/index.rst
@@ -101,17 +101,17 @@ Dictionaries
 	"``DictContainingKeys(keys_list)``", "A dictionary containing all keys from ``keys_list``"
 	"``DictSupersetOf(this_dict)``", "A dictionary containing all key / value pairs from ``this_dict``"
 
-Containers and Iterables
-------------------------
+Collections
+-----------
 .. csv-table::
 	:header: "Matcher", "Description"
 
-	"``AnyContaining(element)``", "Any container that contains ``element``"
-	"``AnyContainingAll(element_list)``", "Any container that contains every element of ``element_list``"
+	"``AnyContaining(element)``", "A container that contains ``element``"
+	"``AnyContainingAll(element_list)``", "A container that contains every element of ``element_list``"
 	"``AnyIterable()``", "Any iterable"
-	"``AnyIterableWithElements(element_list)``", "Any iterable containing all the elements in ``element_list`` in the same order"
-	"``NotEmptyIterable()``", "An iterable with at least one element"
-	"``EmptyIterable()``", "An empty iterable"
+	"``IterableWithElements(element_list)``", "An iterable containing all the elements in ``element_list`` in the same order"
+	"``AnyNotEmpty()``", "An object where ``len()`` does not evaluate to zero"
+	"``AnyEmpty()``", "An object where ``len()`` evaluates to zero"
 
 Generic
 -------

--- a/tests/matchers_unittest.py
+++ b/tests/matchers_unittest.py
@@ -344,25 +344,21 @@ class TestIterable(testslide.TestCase):
         self.assertEqual(testslide.matchers.AnyIterable(), {1, 2, 3})
         self.assertNotEqual(testslide.matchers.AnyIterable(), 10)
 
-    def testAnyIterableWithElements(self):
-        self.assertEqual(
-            testslide.matchers.AnyIterableWithElements([1, 2, 3]), [1, 2, 3]
-        )
+    def testIterableWithElements(self):
+        self.assertEqual(testslide.matchers.IterableWithElements([1, 2, 3]), [1, 2, 3])
         # subset
-        self.assertNotEqual(
-            testslide.matchers.AnyIterableWithElements([1, 2]), [1, 2, 3]
-        )
+        self.assertNotEqual(testslide.matchers.IterableWithElements([1, 2]), [1, 2, 3])
         # non-list
         self.assertEqual(
-            testslide.matchers.AnyIterableWithElements([1, 2, 3]),
+            testslide.matchers.IterableWithElements([1, 2, 3]),
             deque([1, 2, 3], maxlen=100),
         )
         self.assertNotEqual(
-            testslide.matchers.AnyIterableWithElements([2, 3, 4]),
+            testslide.matchers.IterableWithElements([2, 3, 4]),
             deque([1, 2, 3], maxlen=100),
         )
         self.assertEqual(
-            testslide.matchers.AnyIterableWithElements(range(1, 4)),
+            testslide.matchers.IterableWithElements(range(1, 4)),
             [1, 2, 3],
         )
 
@@ -370,7 +366,7 @@ class TestIterable(testslide.TestCase):
         expected_list = [1, 2, 3]
         for MatcherClass in (
             testslide.matchers.AnyContainingAll,
-            testslide.matchers.AnyIterableWithElements,
+            testslide.matchers.IterableWithElements,
         ):
             it = iter(expected_list)
             matcher = MatcherClass(it)
@@ -389,28 +385,32 @@ class TestIterable(testslide.TestCase):
                 expected_list,
             )
 
-    def testEmptyIterable(self):
-        # iterable with len()
-        self.assertEqual(testslide.matchers.EmptyIterable(), [])
-        self.assertEqual(testslide.matchers.EmptyIterable(), {})
-        self.assertNotEqual(testslide.matchers.EmptyIterable(), [1, 2, 3])
-        # iterable without len()
-        self.assertEqual(testslide.matchers.EmptyIterable(), iter([]))
-        self.assertNotEqual(testslide.matchers.EmptyIterable(), iter([1, 2, 3]))
+    def testAnyEmpty(self):
+        # Sized
+        self.assertEqual(testslide.matchers.AnyEmpty(), [])
+        self.assertEqual(testslide.matchers.AnyEmpty(), {})
+        self.assertNotEqual(testslide.matchers.AnyEmpty(), [1, 2, 3])
+        # iterables without len()
         with self.assertRaises(TypeError):
-            self.assertEqual(testslide.matchers.EmptyIterable(), 10)
+            self.assertEqual(testslide.matchers.AnyEmpty(), iter([]))
+        with self.assertRaises(TypeError):
+            self.assertNotEqual(testslide.matchers.AnyEmpty(), iter([1, 2, 3]))
+        with self.assertRaises(TypeError):
+            self.assertEqual(testslide.matchers.AnyEmpty(), 10)
 
-    def testNotEmptyIterable(self):
-        # iterable with len()
-        self.assertNotEqual(testslide.matchers.NotEmptyIterable(), [])
-        self.assertEqual(testslide.matchers.NotEmptyIterable(), [1, 2, 3])
-        self.assertEqual(testslide.matchers.NotEmptyIterable(), {1, 2, 3})
-        # iterable without len()
-        self.assertNotEqual(testslide.matchers.NotEmptyIterable(), iter([]))
-        self.assertEqual(testslide.matchers.NotEmptyIterable(), iter([1, 2, 3]))
+    def testAnyNotEmpty(self):
+        # Sized
+        self.assertNotEqual(testslide.matchers.AnyNotEmpty(), [])
+        self.assertEqual(testslide.matchers.AnyNotEmpty(), [1, 2, 3])
+        self.assertEqual(testslide.matchers.AnyNotEmpty(), {1, 2, 3})
+        # iterables without len()
+        with self.assertRaises(TypeError):
+            self.assertNotEqual(testslide.matchers.AnyNotEmpty(), iter([]))
+        with self.assertRaises(TypeError):
+            self.assertEqual(testslide.matchers.AnyNotEmpty(), iter([1, 2, 3]))
         # not iterable
         with self.assertRaises(TypeError):
-            self.assertEqual(testslide.matchers.NotEmptyIterable(), 10)
+            self.assertEqual(testslide.matchers.AnyNotEmpty(), 10)
 
 
 class TestChaining(testslide.TestCase):

--- a/tests/matchers_unittest.py
+++ b/tests/matchers_unittest.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections import deque
+
 import testslide
 
 from . import sample_module
@@ -295,6 +297,120 @@ class TestDicts(testslide.TestCase):
             testslide.matchers.DictContainingKeys("derp")
         with self.assertRaises(ValueError):
             testslide.matchers.DictContainingKeys({"a", "b", "c"})
+
+
+class TestIterable(testslide.TestCase):
+    def testAnyContaining(self):
+        # list
+        self.assertEqual(testslide.matchers.AnyContaining(1), [1, 2, 3])
+        self.assertNotEqual(testslide.matchers.AnyContaining(1), [2, 3, 4])
+        # non-list collection
+        self.assertEqual(
+            testslide.matchers.AnyContaining(1), deque([1, 2, 3], maxlen=100)
+        )
+        self.assertEqual(
+            testslide.matchers.AnyContaining(1), deque([1, 2, 3], maxlen=100)
+        )
+        # string
+        with self.assertRaises(TypeError):
+            self.assertNotEqual(testslide.matchers.AnyContaining(1), "DERP")
+        self.assertEqual(testslide.matchers.AnyContaining("E"), "DERP")
+        self.assertNotEqual(testslide.matchers.AnyContaining("A"), "DERP")
+
+    def testAnyContainingAll(self):
+        # list
+        self.assertEqual(testslide.matchers.AnyContainingAll([1, 2]), [1, 2, 3])
+        self.assertNotEqual(
+            testslide.matchers.AnyContainingAll([1, 2, 3, 5]), [2, 3, 4]
+        )
+        # non-list
+        self.assertEqual(testslide.matchers.AnyContainingAll([1, 2]), {1, 2, 3})
+        self.assertNotEqual(
+            testslide.matchers.AnyContainingAll([1, 2, 3, 5]), {2, 3, 4}
+        )
+        self.assertEqual(testslide.matchers.AnyContainingAll({1, 2}), [1, 2, 3])
+        self.assertNotEqual(
+            testslide.matchers.AnyContainingAll({1, 2, 3, 5}), [2, 3, 4]
+        )
+        # non-iterables
+        with self.assertRaises(TypeError):
+            self.assertEqual(testslide.matchers.AnyContainingAll(10), [1, 2, 3])
+        with self.assertRaises(TypeError):
+            self.assertEqual(testslide.matchers.AnyContainingAll([1, 2, 3]), 10)
+
+    def testAnyIterable(self):
+        self.assertEqual(testslide.matchers.AnyIterable(), [1, 2, 3])
+        self.assertEqual(testslide.matchers.AnyIterable(), range(3))
+        self.assertEqual(testslide.matchers.AnyIterable(), {1, 2, 3})
+        self.assertNotEqual(testslide.matchers.AnyIterable(), 10)
+
+    def testAnyIterableWithElements(self):
+        self.assertEqual(
+            testslide.matchers.AnyIterableWithElements([1, 2, 3]), [1, 2, 3]
+        )
+        # subset
+        self.assertNotEqual(
+            testslide.matchers.AnyIterableWithElements([1, 2]), [1, 2, 3]
+        )
+        # non-list
+        self.assertEqual(
+            testslide.matchers.AnyIterableWithElements([1, 2, 3]),
+            deque([1, 2, 3], maxlen=100),
+        )
+        self.assertNotEqual(
+            testslide.matchers.AnyIterableWithElements([2, 3, 4]),
+            deque([1, 2, 3], maxlen=100),
+        )
+        self.assertEqual(
+            testslide.matchers.AnyIterableWithElements(range(1, 4)),
+            [1, 2, 3],
+        )
+
+    def testExhaustedIterators(self):
+        expected_list = [1, 2, 3]
+        for MatcherClass in (
+            testslide.matchers.AnyContainingAll,
+            testslide.matchers.AnyIterableWithElements,
+        ):
+            it = iter(expected_list)
+            matcher = MatcherClass(it)
+
+            # verify iterator is exhausted
+            with self.assertRaises(StopIteration):
+                next(it)
+
+            self.assertEqual(
+                matcher,
+                expected_list,
+            )
+            # Asserting against this matcher twice produces the same result
+            self.assertEqual(
+                matcher,
+                expected_list,
+            )
+
+    def testEmptyIterable(self):
+        # iterable with len()
+        self.assertEqual(testslide.matchers.EmptyIterable(), [])
+        self.assertEqual(testslide.matchers.EmptyIterable(), {})
+        self.assertNotEqual(testslide.matchers.EmptyIterable(), [1, 2, 3])
+        # iterable without len()
+        self.assertEqual(testslide.matchers.EmptyIterable(), iter([]))
+        self.assertNotEqual(testslide.matchers.EmptyIterable(), iter([1, 2, 3]))
+        with self.assertRaises(TypeError):
+            self.assertEqual(testslide.matchers.EmptyIterable(), 10)
+
+    def testNotEmptyIterable(self):
+        # iterable with len()
+        self.assertNotEqual(testslide.matchers.NotEmptyIterable(), [])
+        self.assertEqual(testslide.matchers.NotEmptyIterable(), [1, 2, 3])
+        self.assertEqual(testslide.matchers.NotEmptyIterable(), {1, 2, 3})
+        # iterable without len()
+        self.assertNotEqual(testslide.matchers.NotEmptyIterable(), iter([]))
+        self.assertEqual(testslide.matchers.NotEmptyIterable(), iter([1, 2, 3]))
+        # not iterable
+        with self.assertRaises(TypeError):
+            self.assertEqual(testslide.matchers.NotEmptyIterable(), 10)
 
 
 class TestChaining(testslide.TestCase):

--- a/testslide/matchers.py
+++ b/testslide/matchers.py
@@ -3,8 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import re
+from typing import Any as AnyType
 from typing import (
-    Any as AnyType,
     Callable,
     Container,
     Dict,

--- a/testslide/matchers.py
+++ b/testslide/matchers.py
@@ -12,6 +12,7 @@ from typing import (
     List,
     NoReturn,
     Optional,
+    Sized,
     TypeVar,
     Union,
 )
@@ -527,7 +528,7 @@ class AnyIterable(Matcher):
         return True
 
 
-class AnyIterableWithElements(Matcher):
+class IterableWithElements(Matcher):
     def __init__(self, elements: Iterable[AnyType]) -> None:
         self.elements_repr = repr(elements) if elements is not None else ""
         self.elements = list(elements)
@@ -543,20 +544,14 @@ class AnyIterableWithElements(Matcher):
         )
 
 
-class NotEmptyIterable(Matcher):
-    def __eq__(self, other: Iterable[AnyType]) -> bool:  # type: ignore
-        try:
-            return bool(len(other))
-        except TypeError:
-            return bool(list(other))
+class AnyNotEmpty(Matcher):
+    def __eq__(self, other: Sized) -> bool:  # type: ignore
+        return bool(len(other))
 
 
-class EmptyIterable(Matcher):
-    def __eq__(self, other: Iterable[AnyType]) -> bool:  # type: ignore
-        try:
-            return not bool(len(other))
-        except TypeError:
-            return not bool(list(other))
+class AnyEmpty(Matcher):
+    def __eq__(self, other: Sized) -> bool:  # type: ignore
+        return not bool(len(other))
 
 
 # generic


### PR DESCRIPTION
**What:**

Add Collection matchers, as requested in #346

- ``AnyContaining(element)``: A container that contains ``element``
- ``AnyContainingAll(element_list)``: A container that contains every element of ``element_list``
- ``AnyIterable()``: Any iterable
- ``IterableWithElements(element_list)``: an iterable containing all the elements in ``element_list`` in the same order"
- ``AnyNotEmpty()``: An object where ``len()`` does not evaluate to zero"
- ``AnyEmpty()``: An object where ``len()`` evaluates to zero"

**Why:**

Currently, the official matchers support Lists and Dicts, but not much in the way of abstract collections.  This PR enables patterns like:

```
actual = deque([1, 2, 3], maxlen=100)
self.assertEqual(actual, IterableWithElements([1, 2, 3]))
```

**How:**

I added these matchers to matchers.py alongside their List/Dict counterparts.  I added unittests to matchers_unittest.py. Finally, I added documentation in patching/argument_matchers/.

**Risks:**

No risk of breaking existing code, since these are largely standalone, however there are some edge cases for these matchers that may or may not be intuitive to the user.

- `AnyEmpty`/`AnyNotEmpty` rely on `len()`, so they will throw on `AnyEmpty() == iter([1, 2, 3])`, for example.
- `AnyContaining()`/`AnyContainingAll()` rely on `in`, so will try to match anything that implements `__contains__`
    - They may also exhaust iterators leading to unexpected results.

**Checklist**:

<!--
Have you done all of these things?
To check an item, place an "x" in the box like so: "- [x] Tests"
Add "N/A" to the end of each line that's irrelevant to your changes
-->


- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
