### PR TITLE
Updating Testslide to typeguard 3.02

### DIFF
--- a/pytest-testslide/requirements.txt
+++ b/pytest-testslide/requirements.txt
@@ -1,2 +1,2 @@
-pytest~=6.2
+pytest~=7.3
 pytest-asyncio>=0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 psutil>=5.6.7
 Pygments>=2.2.0
-typeguard<3.0
+typeguard~=3.0
 dataclasses>=0.6; python_version < "3.7"

--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -42,9 +42,7 @@ def _validate_callable_arg_types(context):
     def assert_fails(self, *args, **kwargs):
         with self.assertRaisesRegex(
             testslide.lib.TypeCheckError,
-            "Call to "
-            + self.callable_template.__name__
-            + " has incompatible argument types",
+            f"Call to {self.callable_template.__name__} has incompatible argument types",
         ):
             testslide.lib._validate_callable_arg_types(
                 self.skip_first_arg, self.callable_template, args, kwargs
@@ -208,7 +206,7 @@ def _validate_callable_arg_types(context):
                 return sample_module.test_union
 
             @context.example
-            def passes_with_StritMock_without_template(self):
+            def passes_with_StrictMock_without_template(self):
                 self.assert_passes({"StrictMock": StrictMock()})
 
             @context.example("it works with unittest.mock.Mock without spec")
@@ -216,7 +214,7 @@ def _validate_callable_arg_types(context):
                 self.assert_passes({"Mock": unittest.mock.Mock()})
 
             @context.example
-            def passes_with_StritMock_with_valid_template(self):
+            def passes_with_StrictMock_with_valid_template(self):
                 self.assert_passes(
                     {"StrictMock(template=str)": StrictMock(template=str)}
                 )
@@ -226,7 +224,7 @@ def _validate_callable_arg_types(context):
                 self.assert_passes({"Mock(spec=str)": unittest.mock.Mock(spec=str)})
 
             @context.example
-            def fails_with_StritMock_with_invalid_template(self):
+            def fails_with_StrictMock_with_invalid_template(self):
                 self.assert_fails(
                     {"StrictMock(template=dict)": StrictMock(template=dict)}
                 )
@@ -242,7 +240,7 @@ def _validate_callable_arg_types(context):
                 return sample_module.test_tuple
 
             @context.example
-            def passes_with_StritMock_without_template(self):
+            def passes_with_StrictMock_without_template(self):
                 self.assert_passes(
                     {
                         "StrictMock": (
@@ -264,7 +262,7 @@ def _validate_callable_arg_types(context):
                 )
 
             @context.example
-            def passes_with_StritMock_with_valid_template(self):
+            def passes_with_StrictMock_with_valid_template(self):
                 self.assert_passes(
                     {
                         "StrictMock(template=int)": (
@@ -286,7 +284,7 @@ def _validate_callable_arg_types(context):
                 )
 
             @context.example
-            def fails_with_StritMock_with_invalid_template(self):
+            def fails_with_StrictMock_with_invalid_template(self):
                 self.assert_fails(
                     {
                         "StrictMock(template=dict)": (
@@ -366,11 +364,6 @@ def _validate_return_type(context):
     @context.example
     def fails_for_wrong_type(self):
         self.assert_fails(42)
-        # assert_regex = r"(?s)type of return must be .+; got .+ instead: .+Defined"
-        # with self.assertRaisesRegex(TypeError, assert_regex):
-        #    testslide.lib._validate_return_type(
-        #        self.callable_template, 42, self.caller_frame_info
-        #    )
 
     @context.example
     def fails_for_mock_with_wrong_template(self):
@@ -386,7 +379,7 @@ def _validate_return_type(context):
     def fails_for_valid_forward_reference_but_bad_type_passed(self):
         with self.assertRaisesRegex(
             testslide.lib.TypeCheckError,
-            "type of return must be one of .*; got int instead:",
+            "type of return must be .*; got <class 'int'> instead:",
         ):
             testslide.lib._validate_return_type(
                 Foo.get_maybe_foo, 33, self.caller_frame_info

--- a/tests/mock_async_callable_testslide.py
+++ b/tests/mock_async_callable_testslide.py
@@ -169,7 +169,7 @@ def mock_async_callable_tests(context):
 
                 with self.assertRaisesRegex(
                     TypeCheckError,
-                    "^type of return must be a list; got (asyncio|coroutine)",
+                    "^type of return must be typing.List\[str\]; got .+(asyncio|coroutine)",
                 ):
                     await self.callable_target(*self.call_args, **self.call_kwargs)
 
@@ -622,12 +622,8 @@ def mock_async_callable_tests(context):
                     self.target_arg, self.callable_arg
                 ).to_call_original()
                 self.assertEqual(
-                    id(await self.callable_target(*self.call_args, **self.call_kwargs)),
-                    id(
-                        await self.original_callable(
-                            *self.call_args, **self.call_kwargs
-                        )
-                    ),
+                    await self.callable_target(*self.call_args, **self.call_kwargs),
+                    await self.original_callable(*self.call_args, **self.call_kwargs),
                 )
 
         else:


### PR DESCRIPTION
<!--
Thank you for your interest in this project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct of this project which can be found at https://github.com/facebook/TestSlide/blob/main/CODE_OF_CONDUCT.md

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines which can  be found at https://github.com/facebook/TestSlide/blob/main/CONTRIBUTING.md

-->

**What:**

Upgrading to Typeguard 3.02

**Why:**

Keep Testslide up to date

**How:**

* Pin Typeguard version to 3 (3.02 is latest version at this time)
* Update `check_type` Typeguard mock to instead mock `._checkers.check_type_internal`
* Update `qualified_name` Typeguard mock target to internal `._utils.qualified_name`
* Update exception handling to catch `typeguard.TypeCheckError`

Misc.
* Update string concatenation to use f-strings instead
* Typo in unittests: StritMock -> StrictMock
* Remove commented out code
* Add some comments on how why we mock out Typeguard with wrapped calls

**Risks:**

Some error message formats have changed

**Checklist**:

- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->
