### PR TITLE
Update makefile to create virtual environment for running tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install virtualenv
+      run: pip install virtualenv
     - name: Run Tests
       run: TESTSLIDE_FORMAT=progress UNITTEST_VERBOSE=0 make ci V=1
     - name: Coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ TestSlide.egg-info/
 *.vsix
 **/package-lock.json
 .coverage.lcov
+venv/


### PR DESCRIPTION
Summary:
It is an antipattern to require contributors to install tools on their stock python and/or to manually manage virtual environments.

This change ensures that Makefile runs do not expect anything present on the system beyond "stock" python

Running on an host where previously expected tools are not installed
```
maci:testslide/ (maci-venv-support) $ which python
python not found
maci:testslide/ (maci-venv-support) $ which pip
pip not found
maci:testslide/ (maci-venv-support) $ which virtualenv
virtualenv not found
maci:testslide/ (maci-venv-support) $
```
### `make clean`
```
maci:testslide/ (maci-venv-support) $ git clean -fdx
maci:testslide/ (maci-venv-support) $ make clean
SDIST CLEAN
DOCS CLEAN
COVERAGE HTML CLEAN
COVERAGE ERASE
MYPY CLEAN
CLEAN
maci:testslide/ (maci-venv-support) $ git clean -fdx
maci:testslide/ (maci-venv-support) $
```
### `make docs`
```
maci:testslide/ (maci-venv-support) $ git clean -fdx
maci:testslide/ (maci-venv-support) $ make docs
CREATE VIRTUALENV (/Users/maci/github/testslide/venv)
INSTALL BUILD DEPS
INSTALL DEPS
DOCS
maci:testslide/ (maci-venv-support) $ git clean -fdx -n
Would remove docs/_build/
Would remove venv/
maci:testslide/ (maci-venv-support) $
```

### `make format`
```
maci:testslide/ (maci-venv-support) $ git clean -fdx
maci:testslide/ (maci-venv-support) $ make format
CREATE VIRTUALENV (/Users/maci/github/testslide/venv)
INSTALL BUILD DEPS
INSTALL DEPS
FORMAT PYFMT tests testslide util pytest-testslide
FORMAT BLACK tests testslide util pytest-testslide
maci:testslide/ (maci-venv-support) $ git clean -fdx -n
Would remove venv/
maci:testslide/ (maci-venv-support) $
```
### `make tests` and `make coverage_report` work (NOTE: venv is not being recreated as exists already)
```
maci:testslide/ (maci-venv-support) $ git clean -fdx
maci:testslide/ (maci-venv-support) $ make tests
CREATE VIRTUALENV (/Users/maci/github/testslide/venv)
INSTALL BUILD DEPS
INSTALL DEPS
COVERAGE ERASE
UNITTEST tests/accept_any_arg_unittest.py
UNITTEST tests/cli_unittest.py
UNITTEST tests/dsl_unittest.py
UNITTEST tests/matchers_unittest.py
UNITTEST tests/pep487_unittest.py
UNITTEST tests/testcase_unittest.py
TESTSLIDE tests/lib_testslide.py
TESTSLIDE tests/mock_async_callable_testslide.py
TESTSLIDE tests/mock_callable_testslide.py
TESTSLIDE tests/mock_constructor_testslide.py
TESTSLIDE tests/patch_attribute_testslide.py
TESTSLIDE tests/strict_mock_testslide.py
INSTALL pytest_testslide DEPS
PYTEST pytest_testslide
MYPY tests testslide util pytest-testslide
FLAKE8 tests testslide util pytest-testslide
ISORT tests testslide util pytest-testslide
BLACK tests testslide util pytest-testslide
Copyright structure intact for all python files
maci:testslide/ (maci-venv-support) $ make coverage_report
COVERAGE ERASE
UNITTEST tests/accept_any_arg_unittest.py
UNITTEST tests/cli_unittest.py
UNITTEST tests/dsl_unittest.py
UNITTEST tests/matchers_unittest.py
UNITTEST tests/pep487_unittest.py
UNITTEST tests/testcase_unittest.py
TESTSLIDE tests/lib_testslide.py
TESTSLIDE tests/mock_async_callable_testslide.py
TESTSLIDE tests/mock_callable_testslide.py
TESTSLIDE tests/mock_constructor_testslide.py
TESTSLIDE tests/patch_attribute_testslide.py
TESTSLIDE tests/strict_mock_testslide.py
COVERAGE COMBINE
COVERAGE REPORT
maci:testslide/ (maci-venv-support) $
```
### `make sdist` works
```
maci:testslide/ (maci-venv-support) $ git clean -fdx
maci:testslide/ (maci-venv-support) $ make sdist
SDIST
maci:testslide/ (maci-venv-support) $ git clean -fdx -n
Would remove TestSlide.egg-info/
Would remove dist/
maci:testslide/ (maci-venv-support) $
```
### `make ci` works
```
maci:testslide/ (maci-venv-support) $ git clean -fdx
maci:testslide/ (maci-venv-support) $ make ci
CREATE VIRTUALENV (/Users/maci/github/testslide/venv)
INSTALL BUILD DEPS
INSTALL DEPS
COVERAGE ERASE
UNITTEST tests/accept_any_arg_unittest.py
UNITTEST tests/cli_unittest.py
UNITTEST tests/dsl_unittest.py
UNITTEST tests/matchers_unittest.py
UNITTEST tests/pep487_unittest.py
UNITTEST tests/testcase_unittest.py
TESTSLIDE tests/lib_testslide.py
TESTSLIDE tests/mock_async_callable_testslide.py
TESTSLIDE tests/mock_callable_testslide.py
TESTSLIDE tests/mock_constructor_testslide.py
TESTSLIDE tests/patch_attribute_testslide.py
TESTSLIDE tests/strict_mock_testslide.py
INSTALL pytest_testslide DEPS
PYTEST pytest_testslide
MYPY tests testslide util pytest-testslide
FLAKE8 tests testslide util pytest-testslide
ISORT tests testslide util pytest-testslide
BLACK tests testslide util pytest-testslide
Copyright structure intact for all python files
COVERAGE COMBINE
COVERAGE REPORT
DOCS
SDIST
INSTALL LOCAL
maci:testslide/ (maci-venv-support) $
```

**What:**

Ensure that `make {CMD}` work without expectations of developers setup.

**Why:**

Running tests, build documentation or anything from the Makefile requires developer to have some tools installed into their system and by default everything gets installed on the used interpreter.
This is an anti-pattern as python virtual environments are better suited to build developer environments.

**How:**

Ensuring that Makefile defines a `venv` target which ensures that a virtual environment is created with all the needed dependencies and it is used as dependency for all the other targets (ie. format, test, etc.)

**Risks:**

No risks are induced by this PR as it updates makefile and not library code and makefile changes have been verified in the test plan and cross-examined by github actions

**Checklist**:
- [x] Added tests, if you've added code that should be tested
- [x] Updated the documentation, if you've changed APIs
- [x] Ensured the test suite passes
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")

Reviewed By: deathowl

Differential Revision: D46856622

