### PR TITLE
Use venv rather than virtualenv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install virtualenv
-      run: pip install virtualenv
     - name: Run Tests
       run: TESTSLIDE_FORMAT=progress UNITTEST_VERBOSE=0 make ci V=1
     - name: Coveralls

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ all: tests coverage_report docs sdist
 ##
 venv: requirements-dev.txt requirements.txt
 	@printf "${TERM_BRIGHT}CREATE VIRTUALENV (${CURDIR}/venv)\n${TERM_NONE}"
-	${Q} python3 -m virtualenv venv
+	${Q} python3 -m venv venv
 	@printf "${TERM_BRIGHT}INSTALL BUILD DEPS\n${TERM_NONE}"
 	${Q} ${CURDIR}/venv/bin/pip install -r requirements-dev.txt
 	@printf "${TERM_BRIGHT}INSTALL DEPS\n${TERM_NONE}"


### PR DESCRIPTION
Use venv rather than virtualenv

venv has been included as part of the python standard library since 3.3 -- no need to install the third-party virtualenv module

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/TestSlide/pull/357).
* #359
* __->__ #357