### PR TITLE
Pull superficial changes out of #352

### DIFF
--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -42,9 +42,7 @@ def _validate_callable_arg_types(context):
     def assert_fails(self, *args, **kwargs):
         with self.assertRaisesRegex(
             testslide.lib.TypeCheckError,
-            "Call to "
-            + self.callable_template.__name__
-            + " has incompatible argument types",
+            f"Call to {self.callable_template.__name__} has incompatible argument types",
         ):
             testslide.lib._validate_callable_arg_types(
                 self.skip_first_arg, self.callable_template, args, kwargs
@@ -208,7 +206,7 @@ def _validate_callable_arg_types(context):
                 return sample_module.test_union
 
             @context.example
-            def passes_with_StritMock_without_template(self):
+            def passes_with_StrictMock_without_template(self):
                 self.assert_passes({"StrictMock": StrictMock()})
 
             @context.example("it works with unittest.mock.Mock without spec")
@@ -216,7 +214,7 @@ def _validate_callable_arg_types(context):
                 self.assert_passes({"Mock": unittest.mock.Mock()})
 
             @context.example
-            def passes_with_StritMock_with_valid_template(self):
+            def passes_with_StrictMock_with_valid_template(self):
                 self.assert_passes(
                     {"StrictMock(template=str)": StrictMock(template=str)}
                 )
@@ -226,7 +224,7 @@ def _validate_callable_arg_types(context):
                 self.assert_passes({"Mock(spec=str)": unittest.mock.Mock(spec=str)})
 
             @context.example
-            def fails_with_StritMock_with_invalid_template(self):
+            def fails_with_StrictMock_with_invalid_template(self):
                 self.assert_fails(
                     {"StrictMock(template=dict)": StrictMock(template=dict)}
                 )
@@ -242,7 +240,7 @@ def _validate_callable_arg_types(context):
                 return sample_module.test_tuple
 
             @context.example
-            def passes_with_StritMock_without_template(self):
+            def passes_with_StrictMock_without_template(self):
                 self.assert_passes(
                     {
                         "StrictMock": (
@@ -264,7 +262,7 @@ def _validate_callable_arg_types(context):
                 )
 
             @context.example
-            def passes_with_StritMock_with_valid_template(self):
+            def passes_with_StrictMock_with_valid_template(self):
                 self.assert_passes(
                     {
                         "StrictMock(template=int)": (
@@ -286,7 +284,7 @@ def _validate_callable_arg_types(context):
                 )
 
             @context.example
-            def fails_with_StritMock_with_invalid_template(self):
+            def fails_with_StrictMock_with_invalid_template(self):
                 self.assert_fails(
                     {
                         "StrictMock(template=dict)": (
@@ -366,11 +364,6 @@ def _validate_return_type(context):
     @context.example
     def fails_for_wrong_type(self):
         self.assert_fails(42)
-        # assert_regex = r"(?s)type of return must be .+; got .+ instead: .+Defined"
-        # with self.assertRaisesRegex(TypeError, assert_regex):
-        #    testslide.lib._validate_return_type(
-        #        self.callable_template, 42, self.caller_frame_info
-        #    )
 
     @context.example
     def fails_for_mock_with_wrong_template(self):

--- a/testslide/lib.py
+++ b/testslide/lib.py
@@ -157,8 +157,10 @@ def _validate_callable_signature(
     kwargs: Dict[str, Any],
 ) -> bool:
     # python stdlib tests have to exempt some builtins for signature validation tests
-    # they use a giant alloy/deny list, which is impractical here so just ignore
+    # they use a giant allow/deny list, which is impractical here so just ignore
     # all builtins.
+
+    # Ugly hack to make mock objects not be subclass of Mock
     if _is_a_builtin(callable_template):
         return False
     if skip_first_arg and not inspect.ismethod(callable_template):
@@ -257,7 +259,6 @@ def _validate_callable_arg_types(
                 expected_type = argspec.annotations.get(argname)
                 if not expected_type:
                     continue
-
                 _validate_argument_type(expected_type, argname, args[idx])
             except TypeCheckError as type_error:
                 type_errors.append(f"{repr(argname)}: {type_error}")
@@ -273,11 +274,11 @@ def _validate_callable_arg_types(
             type_errors.append(f"{repr(argname)}: {type_error}")
 
     if type_errors:
+        separator = "\n  "
         raise TypeCheckError(
-            "Call to "
-            + callable_template.__name__
-            + " has incompatible argument types:\n  "
-            + "\n  ".join(type_errors)
+            f"Call to {callable_template.__name__} "
+            "has incompatible argument types:\n  "
+            f"{separator.join(type_errors)}"
         )
 
 


### PR DESCRIPTION
Pull superficial changes out of #352

Wanting to try out "upgrade typeguard to 3.X" (#352) and "upgrade typeguard to 4.X" in parallel, pulling some superficial parts out so that I can minimise distractions
