### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+	"name": "TestSlide",
+	"build": {
+		"context": "..",
+		"dockerfile": "../Dockerfile"
+	},
+
+	"workspaceMount": "source=${localWorkspaceFolder},target=/root/src/TestSlide,type=bind",
+	"workspaceFolder": "/root/src/TestSlide",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-azuretools.vscode-docker",
+				"ms-vscode.makefile-tools",
+				"ms-python.python"
+			]
+		}
+	}
+}


### PR DESCRIPTION
Add devcontainer

So that one merely needs to open the project in a supported editor (vscode, github) and the editor will pop up a prompt for "would you like to develop this project inside the container?", and if you click yes then you are straight into a known-good dev environment where you can run "make" and run all the tests
