### PR TITLE
[ci] also test in 3.11 / 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
       # Ensure that all flavours are run to completion even if an other flavor failed
       fail-fast: false
 


### PR DESCRIPTION
[ci] also test in 3.11 / 3.12

3.12 is the current python stable version, we should probably make sure it works?
