### PR TITLE
Fix type signatures in sample module

### DIFF
--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -51,7 +51,7 @@ class SomeUnhashableClass:
     def __init__(self) -> None:
         pass
 
-    def __eq__(self) -> None:
+    def __eq__(self, other) -> bool:
         return True
 
     def method(self) -> int:


### PR DESCRIPTION
Fix type signatures in sample module

mypy is complaining about this and failing all of the builds, and there's no comment saying "this mistake is intentional", so I assume it is an accident
