### PR TITLE
When complaining about a formatting error, say what the error is

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ flake8: venv
 .PHONY: black
 black: venv
 	@printf "${TERM_BRIGHT}BLACK ${ALL_SRCS}\n${TERM_NONE}"
-	${Q} ${CURDIR}/venv/bin/black --check $(ALL_SRCS) || { echo "Formatting errors found, try running 'make format'."; exit 1; }
+	${Q} ${CURDIR}/venv/bin/black --check --diff $(ALL_SRCS) || { echo "Formatting errors found, try running 'make format'."; exit 1; }
 
 .PHONY: isort
 isort: venv


### PR DESCRIPTION
When complaining about a formatting error, say what the error is

I'm getting an error which _only_ appears on python 3.7 and I can't repro it locally, and CI won't tell me what the error is x_x
