### PR TITLE
[wip] Support for py3.11+, see #364

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
       # Ensure that all flavours are run to completion even if an other flavor failed
       fail-fast: false
 

--- a/tests/mock_constructor_testslide.py
+++ b/tests/mock_constructor_testslide.py
@@ -205,13 +205,16 @@ def mock_constructor(context):
                 self.assertEqual(original_target_class.CLASS_ATTR, "CLASS_ATTR")
 
             @context.example
-            def can_call_class_methods(self):
-                for name in [
-                    "regular_class_method",
-                    "p2_super_class_method",
-                    "p3_super_class_method",
-                ]:
-                    self.assertEqual(getattr(original_target_class, name)(), name)
+            def can_call_regular_class_method(self):
+                self.assertEqual(original_target_class.regular_class_method(), "regular_class_method")
+
+            @context.example
+            def can_call_p2_super_class_method(self):
+                self.assertEqual(original_target_class.p2_super_class_method(), "p2_super_class_method")
+
+            @context.example
+            def can_call_p3_super_class_method(self):
+                self.assertEqual(original_target_class.p3_super_class_method(), "p3_super_class_method")
 
             @context.example
             def can_call_static_methods(self):


### PR DESCRIPTION
[wip] Support for py3.11+, see #364

The first attempt was landed too soon and reverted - turns out that 3.11+ actually have real breakages that we need to fix before we can call them supported
