### PR TITLE
Fix pyre type errors that were missed in CI

### DIFF
--- a/testslide/bdd/lib.py
+++ b/testslide/bdd/lib.py
@@ -453,6 +453,7 @@ class _TestSlideTestResult(unittest.TestResult):
         super(_TestSlideTestResult, self).addUnexpectedSuccess(test)
         self._add_exception((type(UnexpectedSuccess), UnexpectedSuccess(), None))  # type: ignore
 
+    # pyre-ignore
     def addSubTest(
         self,
         test: "TestCase",
@@ -462,7 +463,7 @@ class _TestSlideTestResult(unittest.TestResult):
             Optional[BaseException],
             Optional[types.TracebackType],
         ],
-    ) -> None:  # type: ignore
+    ) -> None:
         """Called at the end of a subtest.
         'err' is None if the subtest ended successfully, otherwise it's a
         tuple of values as returned by sys.exc_info().

--- a/testslide/executor/cli.py
+++ b/testslide/executor/cli.py
@@ -155,10 +155,12 @@ def _load_unittest_test_cases(import_module_names: List[str]) -> None:
             return context_code
 
         testslide.bdd.dsl.context(
-            "{}.{}".format(test_case.__module__, test_case.__name__)
-        )(  # type: ignore
-            get_context_code(test_case)
-        )
+            "{}.{}".format(
+                test_case.__module__,
+                # pyre-ignore
+                test_case.__name__,
+            )
+        )(get_context_code(test_case))
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Summary: A bunch of pyre type checking tests were missed in CI, fixing these now.  PART 2

Reviewed By: Sanjay-Ganeshan

Differential Revision: D66970951


