### PR TITLE
Fix StrictMock stub to use class inheriting from Any instead of alias

### DIFF
--- a/testslide/strict_mock.pyi
+++ b/testslide/strict_mock.pyi
@@ -1,4 +1,4 @@
 # pyre-unsafe
 from typing import Any
 
-StrictMock = Any
+class StrictMock(Any): ...


### PR DESCRIPTION
Summary:
The StrictMock type stubs across strictmock and testslide defined `StrictMock = Any`, making it a type alias for `Any`. Pyrefly treats bare `Any` as non-instantiable, causing ~14,700 `bad-instantiation` errors (`Any cannot be instantiated`) across ~3,500 test files in fbcode.

Additionally, when the stub was changed to a plain `class StrictMock`, Pyrefly correctly flagged ~13,500 `bad-argument-type` errors where `StrictMock` instances were passed to functions expecting specific types — which is the intended usage of StrictMock as a mock stand-in.

The fix changes all four stub files from:
```
StrictMock = Any
```
to:
```
class StrictMock(Any): ...
```

This makes StrictMock an instantiable class that inherits from Any, so it is both constructible and assignable to any type — matching its real-world usage as a universal mock object.

Affected stubs:
- fbcode/strictmock/strict_mock.pyi
- fbcode/testslide/testslide/strict_mock.pyi
- fbcode/python/typeshed_internal/testslide/core/strict_mock.pyi
- fbcode/python/typeshed_experimental/testslide/core/strict_mock.pyi

Differential Revision: D97783042


