### PR TITLE
Validate contextmanager return types against the context manager

### DIFF
--- a/tests/lib_testslide.py
+++ b/tests/lib_testslide.py
@@ -377,6 +377,32 @@ def _validate_return_type(context):
         )
 
     @context.example
+    def passes_for_context_manager_template(self):
+        """
+        contextlib.contextmanager copies __annotations__ from the generator
+        function it wraps, so the recorded return type describes what the
+        generator yields rather than the context manager that calling it
+        actually returns.
+        https://github.com/facebook/TestSlide/issues/193
+        """
+        self.callable_template = sample_module.test_function_returns_context_manager
+        self.assert_passes(StrictMock(template=sample_module.ContextManagerTarget))
+
+    @context.example
+    def passes_for_async_context_manager_template(self):
+        """Same as above, for contextlib.asynccontextmanager."""
+        self.callable_template = (
+            sample_module.test_function_returns_async_context_manager
+        )
+        self.assert_passes(StrictMock(template=sample_module.ContextManagerTarget))
+
+    @context.example
+    def fails_for_context_manager_template_given_a_non_context_manager(self):
+        """The check is redirected, not disabled."""
+        self.callable_template = sample_module.test_function_returns_context_manager
+        self.assert_fails(42)
+
+    @context.example
     def fails_for_valid_forward_reference_but_bad_type_passed(self):
         with self.assertRaisesRegex(
             testslide.lib.TypeCheckError,

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -3,8 +3,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections.abc import Awaitable, Coroutine
+from collections.abc import AsyncGenerator, Awaitable, Coroutine, Generator
+from contextlib import asynccontextmanager, contextmanager
 from typing import Any, Union
+
+from typing_extensions import Self
 
 attribute = "value"
 typedattr: str = "bruh"
@@ -175,3 +178,35 @@ TupleArgType = dict[str, tuple[str, int]]
 
 def test_tuple(arg: TupleArgType) -> None:
     pass
+
+
+class ContextManagerTarget:
+    "This class is used by some unit tests only"
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+
+@contextmanager
+def test_function_returns_context_manager() -> Generator[
+    "ContextManagerTarget", None, None
+]:
+    "This function is used by some unit tests only"
+    yield ContextManagerTarget()
+
+
+@asynccontextmanager
+async def test_function_returns_async_context_manager() -> AsyncGenerator[
+    "ContextManagerTarget", None
+]:
+    "This function is used by some unit tests only"
+    yield ContextManagerTarget()

--- a/testslide/core/lib.py
+++ b/testslide/core/lib.py
@@ -5,6 +5,7 @@
 
 # pyre-unsafe
 import collections.abc as abc
+import contextlib
 import functools
 import inspect
 import os
@@ -341,6 +342,33 @@ def _is_wrapped_for_signature_and_type_validation(value: Callable) -> bool:
     return getattr(value, "__is_testslide_type_validation_wrapping", False)
 
 
+def _get_contextmanager_return_type(template: Any) -> Any:
+    """Return the context manager type produced by a contextlib-decorated function.
+
+    ``contextlib.contextmanager`` and ``contextlib.asynccontextmanager`` wrap the
+    decorated generator function with ``functools.wraps``, which copies
+    ``__annotations__`` over verbatim. The recorded return type therefore
+    describes what the *generator* yields (eg ``AsyncGenerator[Foo, None]``),
+    while calling the decorated function actually returns a context manager.
+    Validating a mocked return value against the generator type rejects every
+    legitimate value.
+
+    Returns ``None`` when ``template`` is not such a decorated function.
+    """
+    wrapped = getattr(template, "__wrapped__", None)
+    if wrapped is None:
+        return None
+    # The decorator turns a generator function into one that is no longer a
+    # generator function, which is what distinguishes it from @wraps in general.
+    if inspect.isasyncgenfunction(wrapped) and not inspect.isasyncgenfunction(template):
+        return contextlib.AbstractAsyncContextManager
+    if inspect.isgeneratorfunction(wrapped) and not inspect.isgeneratorfunction(
+        template
+    ):
+        return contextlib.AbstractContextManager
+    return None
+
+
 def _validate_return_type(
     template: Mock | Callable,
     value: Any,
@@ -352,6 +380,9 @@ def _validate_return_type(
     except TypeError:
         return
     expected_type = argspec.annotations.get("return")
+    contextmanager_type = _get_contextmanager_return_type(template)
+    if contextmanager_type is not None:
+        expected_type = contextmanager_type
     if expected_type:
         if unwrap_template_awaitable:
             type_origin = get_origin(expected_type)


### PR DESCRIPTION
Fixes #193. The issue is from 2020 but still reproduces on current `main` (555422d) — repro below.

## Cause

`contextlib.contextmanager` and `contextlib.asynccontextmanager` wrap the decorated generator function with `functools.wraps`, which copies `__annotations__` over verbatim. So for

```python
@asynccontextmanager
async def get_cm() -> AsyncGenerator[Foo, None]:
    yield Foo()
```

the recorded return type is `AsyncGenerator[Foo, None]` — what the *generator* yields — while calling `get_cm()` actually returns an `_AsyncGeneratorContextManager`.

`_validate_return_type` reads that annotation straight off the template, so mocking the function rejects every legitimate return value:

```
TypeCheckError: type of return must be typing.AsyncGenerator[foo.Foo, NoneType];
got <class 'testslide.core.strict_mock.FooStrictMock'> instead
```

There is no return value that could satisfy it — the annotation describes something the caller never receives.

## Reproduction

Exactly the files from #193; `testslide test_foo.py` fails before this change and passes after.

<details><summary>foo.py / test_foo.py</summary>

```python
# foo.py
from contextlib import asynccontextmanager
from typing import AsyncGenerator


class Foo:
    async def bar(self) -> int:
        return 1

    async def __aenter__(self):
        return self

    async def __aexit__(self, exc_type, exc, tb):
        return


@asynccontextmanager
async def get_cm() -> AsyncGenerator[Foo, None]:
    yield Foo()


async def call_bar() -> int:
    async with get_cm() as foo:
        return await foo.bar()
```

```python
# test_foo.py
from testslide.dsl import context
from testslide import StrictMock
from foo import call_bar, Foo

module = "foo"


@context
def foo_test(context):
    context.memoize(
        "foo_mock", lambda self: StrictMock(template=Foo, default_context_manager=True)
    )

    @context.before
    async def mock_get_cm(self):
        self.mock_callable(module, "get_cm").to_return_value(self.foo_mock)
        self.mock_async_callable(self.foo_mock, "bar").to_return_value(3)

    @context.example
    async def test_bar(self):
        self.assertEqual(await call_bar(), 3)
```
</details>

## Approach

Detect the decoration by comparing the template against its `__wrapped__`: contextlib turns a generator function into one that is *no longer* a generator function, which is what distinguishes it from `functools.wraps` in general. The expected type then becomes `contextlib.AbstractContextManager` / `AbstractAsyncContextManager`.

I used the unparameterized ABCs deliberately. The yielded type is produced later by `__aenter__`, so it is not present in the value being validated and cannot be checked at this point; claiming `AsyncContextManager[Foo]` would be checking something we cannot see. Happy to change if you would rather keep the parameter for readability.

**The check is redirected, not disabled** — a non-context-manager return value is still rejected. `fails_for_context_manager_template_given_a_non_context_manager` asserts that, so this cannot silently rot into "no validation".

## Tests

Adds a `ContextManagerTarget` fixture (implements both the sync and async protocols) plus decorated factories to `tests/sample_module.py`, and three examples to the `_validate_return_type` context. The two positive ones fail without the change with exactly the error from the issue.

Verified on Windows / Python 3.13:

- `lib`, `mock_callable`, `mock_async_callable`, `strict_mock`, `mock_constructor`, `patch_attribute`: **2865 successful, 4 failed, 62 skipped** — identical baseline of 4 pre-existing failures before and after; the 3 new successes are mine.
- unittest suites: 141 tests, only `cli_unittest` erroring, which is `import pty` being Unix-only, and reproduces on a clean checkout.
- `ruff check` back to the same 22 pre-existing findings; `flake8 --select=F,C90` clean. I left the pre-existing `ruff format` deviation in `sample_module.py` (a lambda in `Target.__init__`) untouched so the diff stays on topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)