### PR TITLE
Don't call property getters when patching attributes

### DIFF
--- a/tests/mock_callable_testslide.py
+++ b/tests/mock_callable_testslide.py
@@ -121,6 +121,19 @@ def mock_callable_tests(context):
         self.mock_callable(t3, "method").to_return_value(2).and_assert_called_once()
         self.assertEqual(t3.method(), 2)
 
+    @context.example
+    def mock_callable_fails_for_properties_without_calling_them(self):
+        class SampleClass:
+            @property
+            def prop(self):
+                raise RuntimeError("must not be called")
+
+        host = SampleClass()
+        with self.assertRaisesRegex(
+            ValueError, "can not be used with properties"
+        ):
+            self.mock_callable(host, "prop")
+
     ##
     ## Shared Contexts
     ##

--- a/tests/patch_attribute_testslide.py
+++ b/tests/patch_attribute_testslide.py
@@ -217,3 +217,67 @@ def patch_attribute_tests(context):
         self.patch_attribute(
             sample_module.SomeClass, "_private_attr", "notsoprivate", allow_private=True
         )
+
+    @context.example
+    def patch_attribute_does_not_call_property_getter(self):
+        class SampleClass:
+            def __init__(self):
+                self._getter_called = False
+
+            @property
+            def prop(self):
+                self._getter_called = True
+                return "original"
+
+        host = SampleClass()
+        self.patch_attribute(host, "prop", "patched")
+        self.assertFalse(host._getter_called, "getter was called during patching")
+        self.assertEqual(host.prop, "patched")
+
+    @context.example
+    def patch_attribute_works_for_properties_that_raise(self):
+        class SampleClass:
+            @property
+            def prop(self):
+                raise RuntimeError("must not be called")
+
+        host = SampleClass()
+        self.patch_attribute(host, "prop", "patched")
+        self.assertEqual(host.prop, "patched")
+
+    @context.example
+    def patch_attribute_unpatches_property_correctly(self):
+        class SampleClass:
+            @property
+            def prop(self):
+                return "original"
+
+        host = SampleClass()
+        self.patch_attribute(host, "prop", "patched")
+        self.assertEqual(host.prop, "patched")
+        unpatch_all_mocked_attributes()
+        self.assertEqual(host.prop, "original")
+
+    @context.example
+    def patch_attribute_unpatches_property_correctly_when_getter_returns_falsy(self):
+        class SampleClass:
+            @property
+            def prop(self):
+                return None
+
+        host = SampleClass()
+        self.patch_attribute(host, "prop", "patched")
+        self.assertEqual(host.prop, "patched")
+        unpatch_all_mocked_attributes()
+        self.assertEqual(host.prop, None)
+
+    @context.example
+    def patch_attribute_validates_property_type_against_getter_annotation(self):
+        class SampleClass:
+            @property
+            def prop(self) -> int:
+                return 1
+
+        host = SampleClass()
+        with self.assertRaises(TypeCheckError):
+            self.patch_attribute(host, "prop", "notanint")

--- a/testslide/core/mock_callable.py
+++ b/testslide/core/mock_callable.py
@@ -722,6 +722,14 @@ class _MockCallableDSL:
                     "assertions on calls are ambiguous (for every instance or one "
                     "global assertion?)."
                 )
+            if hasattr(type(self._target), self._method) and isinstance(
+                getattr(type(self._target), self._method), property
+            ):
+                raise ValueError(
+                    f"{name}() can not be used with properties: "
+                    f"{repr(self._method)} is a property. Use patch_attribute() "
+                    "to patch its value."
+                )
             original_callable = getattr(self._target, self._method)
             if not callable(original_callable):
                 raise ValueError(

--- a/testslide/core/patch.py
+++ b/testslide/core/patch.py
@@ -97,10 +97,10 @@ def _patch(
         setattr(type(target), attribute, property(fget=lambda _: new_value))
 
         def unpatcher() -> None:
-            if restore_value:
-                setattr(type(target), attribute, original_property)
-            else:
-                delattr(target, attribute)
+            # The patch always replaces the class attribute with a new property,
+            # so unpatching always means restoring the original property, no
+            # matter what the patched value was.
+            setattr(type(target), attribute, original_property)
 
     else:
         setattr(target, attribute, new_value)

--- a/testslide/core/patch_attribute.py
+++ b/testslide/core/patch_attribute.py
@@ -87,13 +87,23 @@ def patch_attribute(
             restore_value = None
         skip_unpatcher = False
     else:
+        is_property = hasattr(type(target), attribute) and isinstance(
+            getattr(type(target), attribute), property
+        )
         if key in _unpatchers:
             restore = False
             restore_value = _restore_values[key]
             skip_unpatcher = True
         else:
             restore = True
-            restore_value = getattr(target, attribute)
+            if is_property:
+                # Accessing the property would call its getter, which may have
+                # side effects or raise exceptions, eg when it calls an external
+                # service that is not available during tests. Save the property
+                # itself instead, so it can be restored later.
+                restore_value = getattr(type(target), attribute)
+            else:
+                restore_value = getattr(target, attribute)
             skip_unpatcher = False
         if isinstance(restore_value, type):
             raise ValueError(
@@ -105,7 +115,17 @@ def patch_attribute(
                 "You can either use mock_callable() / mock_async_callable() instead."
             )
         if type_validation:
-            _validate_argument_type(type(restore_value), attribute, new_value)
+            if is_property:
+                # The property getter should not be called just to figure out the
+                # type of the value. Validate against the getter's return type
+                # annotation, when available.
+                expected_type = getattr(
+                    getattr(restore_value, "fget", None), "__annotations__", {}
+                ).get("return")
+                if expected_type is not None:
+                    _validate_argument_type(expected_type, attribute, new_value)
+            else:
+                _validate_argument_type(type(restore_value), attribute, new_value)
 
     if restore:
         _restore_values[key] = restore_value


### PR DESCRIPTION
## Summary

Fixes #339.

`patch_attribute()` used to call `getattr(target, attribute)` to capture the value to restore later. When the attribute is a `@property`, this invokes the property getter at patch time, which:

- triggers any side effects the getter has;
- propagates exceptions the getter raises (eg a property that calls an external service unavailable during tests) — exactly the case mocking is supposed to protect against.

This changes patching to save the **property object itself** when the attribute is a class-level property, so the getter is never called during setup. The class-level property is restored on unpatch.

Also fixes the property-branch unpatcher in `core/patch.py`: it now always restores the original class property instead of branching on the truthiness of the restored value (which would `delattr` the instance and fail to restore the class property when the getter returned a falsy value).

When type validation is enabled, the new value is validated against the property getter's `return` annotation (when present), rather than the type of the value produced by calling the getter.

`mock_callable()` against a property is now rejected with a clear `ValueError` ("can not be used with properties... Use patch_attribute()") instead of silently calling the getter, which could propagate its exception.

## Tests

Added coverage in `tests/patch_attribute_testslide.py` and `tests/mock_callable_testslide.py`:
- patching a property does not call its getter;
- patching a property whose getter raises works;
- unpatching a property restores the original behavior, including when the getter returned a falsy value;
- type validation uses the getter's return annotation;
- `mock_callable` on a property raises `ValueError` without calling the getter.